### PR TITLE
Add Legacy, Ruby, and Java TimestampFormatter for parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: java
+jdk:
+  - oraclejdk8
+
+# Travis CI is to be configured to build both pushed branches and pull requests.
+# See: https://travis-ci.org/embulk/embulk-util-timestamp/settings
+#
+# A pushed branch triggers a build only if it's the master branch.
+# A pushed pull request always triggers a build.
+branches:
+  only:
+  - master

--- a/NOTICE
+++ b/NOTICE
@@ -1,23 +1,2 @@
-embulk-util-rubytime
-Copyright 2018 The Embulk Project
-
-This product includes some source code from Matz’s Ruby Interpreter.
-* Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
-* https://www.ruby-lang.org/
-* Licensed under the 2-clause BSDL
-* The copy from Matz’s Ruby Interpreter is used only for testing this product.
-* The binary distribution of this product does not include source code from Matz’s Ruby Interpreter.
-
-This product includes software from the test-unit project.
-* Copyright (c) Kouhei Sutou <kou@cozmixng.org>, Ryan Davis <ryand-ruby@zenspider.com> and Nathaniel Talbott <nathaniel@talbott.ws>
-* https://github.com/test-unit/test-unit
-* Licensed under the GPL version 2
-* The test-unit project is used only for testing this product.
-* The binary distribution of this product does not include test-unit.
-
-This product includes software from the power_assert project.
-* Copyright (C) 2014 Kazuki Tsujimoto
-* https://github.com/k-tsj/power_assert
-* Licensed under the 2-clause BSDL
-* The power_assert project is used only for testing this product.
-* The binary distribution of this product does not include power_assert.
+embulk-util-timestamp
+Copyright 2019 The Embulk Project

--- a/build.gradle
+++ b/build.gradle
@@ -10,12 +10,21 @@ description "Timestamp parser for Embulk and Embulk plugins"
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+configurations {
+    javadocOnly { transitive false }
+}
+
 repositories {
     mavenCentral()
 }
 
 dependencies {
     implementation "org.embulk:embulk-util-rubytime:0.2.0"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.3.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.3.1"
+
+    javadocOnly "joda-time:joda-time:2.10.2"
 }
 
 tasks.withType(JavaCompile) {
@@ -26,10 +35,12 @@ tasks.withType(JavaCompile) {
 javadoc {
     title = "${project.name} v${project.version}"
     options {
+        classpath += configurations.javadocOnly
         locale = "en_US"
         encoding = "UTF-8"
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
+        links "https://www.joda.org/joda-time/apidocs/"
     }
 }
 

--- a/src/main/java/org/embulk/util/timestamp/JavaTimestampFormatter.java
+++ b/src/main/java/org/embulk/util/timestamp/JavaTimestampFormatter.java
@@ -1,0 +1,159 @@
+package org.embulk.util.timestamp;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.util.Locale;
+
+class JavaTimestampFormatter extends TimestampFormatter {
+    JavaTimestampFormatter(final String pattern, final ZoneOffset defaultZoneOffset) {
+        this.formatter = new DateTimeFormatterBuilder()
+                                 .parseCaseInsensitive()
+                                 .appendPattern(pattern)
+                                 .toFormatter(Locale.ENGLISH)
+                                 .withResolverStyle(ResolverStyle.STRICT);
+        this.pattern = pattern;
+        this.defaultZoneOffset = defaultZoneOffset;
+    }
+
+    @Override
+    public final Instant parse(final String text) {
+        if (text == null) {
+            throw new DateTimeParseException("text is null.", text, 0, new NullPointerException());
+        } else if (text.isEmpty()) {
+            throw new DateTimeParseException("text is empty.", text, 0);
+        }
+
+        final TemporalAccessor temporal = this.formatter.parse(text);
+        return this.buildOffsetDateTime(temporal, text).toInstant();
+    }
+
+    private OffsetDateTime buildOffsetDateTime(final TemporalAccessor given, final String text) {
+        // Non-offset (string-ish) time zone IDs are intentionally rejected by JavaTimestampFormatter.
+        // because their meanings are not stable per the tz database.
+        final ZoneId givenZoneId = given.query(TemporalQueries.zoneId());
+        if (givenZoneId != null) {
+            throw new DateTimeParseException("Non-offset zone IDs are unaccepted in 'java:' formats: " + this.pattern, text, 0);
+        }
+
+        final ZoneOffset givenZoneOffset = given.query(TemporalQueries.offset());
+        if (given.isSupported(ChronoField.EPOCH_DAY) && given.isSupported(ChronoField.NANO_OF_DAY)) {
+            // Normal fastest cases: Embulk expects the record has full date and time information in most cases.
+            if (givenZoneOffset != null) {
+                return OffsetDateTime.from(given);
+            } else {
+                return OffsetDateTime.of(LocalDateTime.from(given), this.defaultZoneOffset);
+            }
+        }
+
+        // Exceptional cases: the record does not have full date and time information.
+        final LocalDate dateFromDefault;
+        if (given.isSupported(ChronoField.EPOCH_DAY)) {
+            dateFromDefault = LocalDate.from(given);
+        } else {
+            final int year;
+            if (given.isSupported(ChronoField.YEAR)) {
+                year = given.get(ChronoField.YEAR);
+            } else if (given.isSupported(ChronoField.YEAR_OF_ERA)) {
+                year = given.get(ChronoField.YEAR_OF_ERA);
+            } else {
+                year = 1970;
+            }
+
+            if (given.isSupported(ChronoField.DAY_OF_YEAR)) {
+                dateFromDefault = LocalDate.ofYearDay(year, given.get(ChronoField.DAY_OF_YEAR));
+            } else {
+                final int month;
+                if (given.isSupported(ChronoField.MONTH_OF_YEAR)) {
+                    month = given.get(ChronoField.MONTH_OF_YEAR);
+                } else {
+                    month = 1;
+                }
+                final int dayOfMonth;
+                if (given.isSupported(ChronoField.DAY_OF_MONTH)) {
+                    dayOfMonth = given.get(ChronoField.DAY_OF_MONTH);
+                } else {
+                    dayOfMonth = 1;
+                }
+                dateFromDefault = LocalDate.of(year, month, dayOfMonth);
+            }
+        }
+
+        final LocalTime timeFromDefault;
+        if (given.isSupported(ChronoField.NANO_OF_DAY)) {
+            timeFromDefault = LocalTime.from(given);
+        } else {
+            if (given.isSupported(ChronoField.NANO_OF_DAY)) {
+                timeFromDefault = LocalTime.ofNanoOfDay(given.getLong(ChronoField.NANO_OF_DAY));
+            } else if (given.isSupported(ChronoField.MILLI_OF_DAY)) {
+                timeFromDefault = LocalTime.ofNanoOfDay(given.getLong(ChronoField.MILLI_OF_DAY) * 1000000L);
+            } else if (given.isSupported(ChronoField.SECOND_OF_DAY)) {
+                timeFromDefault = LocalTime.ofSecondOfDay(given.getLong(ChronoField.SECOND_OF_DAY));
+            } else if (given.isSupported(ChronoField.MINUTE_OF_DAY)) {
+                timeFromDefault = LocalTime.ofSecondOfDay(given.getLong(ChronoField.MINUTE_OF_DAY) * 60L);
+            } else {
+                final int hourOfDay;
+                if (given.isSupported(ChronoField.HOUR_OF_DAY)) {
+                    hourOfDay = given.get(ChronoField.HOUR_OF_DAY);
+                } else if (given.isSupported(ChronoField.CLOCK_HOUR_OF_DAY)) {
+                    hourOfDay = given.get(ChronoField.CLOCK_HOUR_OF_DAY) % 24;
+                } else if (given.isSupported(ChronoField.AMPM_OF_DAY)) {
+                    final int ampmOfDay = given.get(ChronoField.AMPM_OF_DAY) * 12;
+                    if (given.isSupported(ChronoField.HOUR_OF_AMPM)) {
+                        hourOfDay = given.get(ChronoField.HOUR_OF_AMPM) + ampmOfDay;
+                    } else if (given.isSupported(ChronoField.CLOCK_HOUR_OF_AMPM)) {
+                        hourOfDay = given.get(ChronoField.CLOCK_HOUR_OF_AMPM) + ampmOfDay;
+                    } else {
+                        hourOfDay = 0;
+                    }
+                } else {
+                    hourOfDay = 0;
+                }
+                final int minuteOfHour;
+                if (given.isSupported(ChronoField.MINUTE_OF_HOUR)) {
+                    minuteOfHour = given.get(ChronoField.MINUTE_OF_HOUR);
+                } else {
+                    minuteOfHour = 0;
+                }
+                final int secondOfMinute;
+                if (given.isSupported(ChronoField.SECOND_OF_MINUTE)) {
+                    secondOfMinute = given.get(ChronoField.SECOND_OF_MINUTE);
+                } else {
+                    secondOfMinute = 0;
+                }
+                final int nanoOfSecond;
+                if (given.isSupported(ChronoField.NANO_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.NANO_OF_SECOND);
+                } else if (given.isSupported(ChronoField.MICRO_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.MICRO_OF_SECOND) * 1000;
+                } else if (given.isSupported(ChronoField.MILLI_OF_SECOND)) {
+                    nanoOfSecond = given.get(ChronoField.MILLI_OF_SECOND) * 1000000;
+                } else {
+                    nanoOfSecond = 0;
+                }
+                timeFromDefault = LocalTime.of(hourOfDay, minuteOfHour, secondOfMinute, nanoOfSecond);
+            }
+        }
+
+        if (givenZoneOffset != null) {
+            return OffsetDateTime.of(dateFromDefault, timeFromDefault, givenZoneOffset);
+        } else {
+            return OffsetDateTime.of(dateFromDefault, timeFromDefault, this.defaultZoneOffset);
+        }
+    }
+
+    private final DateTimeFormatter formatter;
+    private final String pattern;
+    private final ZoneOffset defaultZoneOffset;
+}

--- a/src/main/java/org/embulk/util/timestamp/LegacyDateTimeZones.java
+++ b/src/main/java/org/embulk/util/timestamp/LegacyDateTimeZones.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.timestamp;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.embulk.util.rubytime.RubyDateTimeZones;
+
+/**
+ * This class contains a {@code static} method to interpret a timezone string
+ * in the historical manner of legacy Embulk.
+ *
+ * <h3>American timezones</h3>
+ *
+ * <p>Legacy Embulk's {@code org.embulk.spi.time.TimestampParser} starts interpreting a timezone
+ * string from Joda-Time's {@link org.joda.time.format.DateTimeFormat} like below. It was before
+ * straightforward {@link org.joda.time.DateTimeZone#forID(java.lang.String) DateTimeZone#forID}
+ * and {@link org.joda.time.DateTimeZone#getAvailableIDs() DateTimeZone#getAvailableIDs}.
+ *
+ * <pre>{@code DateTimeFormat.forPattern("z").parseMillis("PDT")}</pre>
+ *
+ * <p>It had been in Embulk since
+ * <a href="https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05#diff-68c6408e7c936d783784945d87fb251bR49">
+ * {@code v0.1.0}</a> until
+ * <a href="https://github.com/embulk/embulk/blob/v0.8.20/embulk-core/src/main/java/org/embulk/spi/time/TimestampFormat.java#L40-L70">
+ * {@code v0.8.20}</a>. <a href="https://github.com/embulk/embulk/issues/860">GitHub Issue #860</a>
+ * describes the details.
+ *
+ * <p>It unfortunately caused some wrong conversions for some American timezones: {@code "EST"},
+ * {@code "EDT"}, {@code "CST"}, {@code "CDT"}, {@code "MST"}, {@code "MDT"}, {@code "PST"}, and
+ * {@code "PDT"}. For example, {@code "PDT"} should be recognized as {@code "-07:00"} because
+ * {@code "PDT"} was a daylight saving time. But, {@code "PDT"} was actually recognized as
+ * {@code "-08:00"} along with {@code "PST"}.
+ *
+ * <p>It was because {@code "PDT"} and {@code "PST"} were aliases of {@code "America/Los_Angeles"}
+ * in Joda-Time, not aliases of a fixed offset. Joda-Time originally intends to recognize both
+ * {@code "PDT"} and {@code "PST"} to be aligned with the date-time with the timezone. For example,
+ * {@code "2017-08-20 12:34:56 PST"} goes to {@code "2017-08-20 12:34:56 America/Los_Angeles"},
+ * and this {@code "America/Los_Angeles"} is recognized as {@code "-07:00"} because the date was
+ * in the daylight saving time. Same for {@code "2017-08-20 12:34:56 PDT"}. This {@code "PDT"} is
+ * eventually recognized as the same {@code "-07:00"} because of the date as well.
+ *
+ * <p>However, {@code DateTimeFormat.forPattern("z").parseMillis("PDT")} was always converted to
+ * {@code "-08:00"} because the string, only {@code "PDT"}, does not have any date information.
+ * Legacy Embulk never recognized {@code "PDT"} as {@code "-07:00"} even for summer as a result.
+ *
+ * <p>JFYI, the set of special timezones comes from
+ * <a href="https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L432-L448">
+ * {@code DateTimeUtils#buildDefaultTimeZoneNames}</a>.
+ *
+ * <h3>"HST" and "ROC"</h3>
+ *
+ * <p>Embulk replaced Joda-Time into {@linkplain java.time Java Date and Time API} when upgraded
+ * to Embulk v0.9. It started to use {@link java.time.ZoneId#of(String, java.util.Map) ZoneId.of}
+ * instead of {@link org.joda.time.DateTimeZone#forID(String) DateTimeZone.forId} at that time.
+ *
+ * <p>{@link java.time.ZoneId#of(String)} does not recognize {@code "HST"} nor {@code "ROC"} that
+ * are recognized by {@link org.joda.time.DateTimeZone#forID(String)}.
+ *
+ * <p>Available timezones in Joda-Time are described in
+ * <a href="http://joda-time.sourceforge.net/timezones.html">
+ * Joda-Time - Java date and time API - Time Zones</a>.
+ *
+ * @see org.joda.time.DateTimeUtils#getDefaultTimeZoneNames()
+ */
+public final class LegacyDateTimeZones {
+    private LegacyDateTimeZones() {
+        // No instantiation.
+    }
+
+    /**
+     * Converts a timezone string to {@link java.time.ZoneId} in legacy Embulk's manner.
+     *
+     * <p>It recognizes a timezone string in the following priority.
+     *
+     * <ol>
+     * <li>{@code "Z"} is always recognized as UTC in the highest priority.
+     * <li>Some special timezone strings are recognized by
+     * {@link java.time.ZoneId#of(String, java.util.Map) ZoneId.of(String, Map)}
+     * with a predefined alias map like below for legacy historical reasons.
+     * <ul>
+     * <li>{@code "EST"} is recognized as {@code "-05:00"}.
+     * <li>{@code "EDT"} is recognized as {@code "-05:00"}, too.
+     * <li>{@code "CST"} is recognized as {@code "-06:00"}.
+     * <li>{@code "CDT"} is recognized as {@code "-06:00"}, too.
+     * <li>{@code "MST"} is recognized as {@code "-07:00"}.
+     * <li>{@code "MDT"} is recognized as {@code "-07:00"}, too.
+     * <li>{@code "PST"} is recognized as {@code "-08:00"}.
+     * <li>{@code "PDT"} is recognized as {@code "-08:00"}, too.
+     * <li>{@code "HST"} is recognized as {@code "-10:00"}.
+     * <li>{@code "ROC"} is recognized as the same as {@code "Asia/Taipei"}.
+     * </ul>
+     * <li>Otherwise, the given timezone string is recognized as Ruby-compatible zone tab.
+     * <li>If none of the above rules does not recognize the given timezone string, it returns {@code null}.
+     * </ol>
+     *
+     * <p>Some of its time offset transition (e.g. daylight saving time) can be different from
+     * Embulk's actual historical transitions. But, the difference comes from their tz database
+     * version difference. The difference should be acceptable as users should expect tz database
+     * can be updated anytime.
+     *
+     * @param zoneName  a timezone string
+     * @return a {@link java.time.ZoneId} converted
+     */
+    public static ZoneId toZoneId(final String zoneName) {
+        if (zoneName == null) {
+            return null;
+        }
+
+        if (zoneName.equals("Z")) {
+            return ZoneOffset.UTC;
+        }
+
+        try {
+            return ZoneId.of(zoneName, ALIASES);  // Is never returns null unless Exception is thrown.
+        } catch (final DateTimeException ex) {
+            // Fallback to Ruby's Date._strptime.
+            final int offsetInSeconds = RubyDateTimeZones.toOffsetInSeconds(zoneName);
+            if (offsetInSeconds != Integer.MIN_VALUE) {
+                return ZoneOffset.ofTotalSeconds(offsetInSeconds);
+            }
+        }
+        return null;
+    }
+
+    static {
+        final HashMap<String, String> aliases = new HashMap<>();
+        aliases.put("EST", "-05:00");
+        aliases.put("EDT", "-05:00");
+        aliases.put("CST", "-06:00");
+        aliases.put("CDT", "-06:00");
+        aliases.put("MST", "-07:00");
+        aliases.put("MDT", "-07:00");
+        aliases.put("PST", "-08:00");
+        aliases.put("PDT", "-08:00");
+
+        aliases.put("HST", "-10:00");
+        aliases.put("ROC", "Asia/Taipei");
+
+        ALIASES = Collections.unmodifiableMap(aliases);
+    }
+
+    private static final Map<String, String> ALIASES;
+}

--- a/src/main/java/org/embulk/util/timestamp/LegacyRubyTimeResolver.java
+++ b/src/main/java/org/embulk/util/timestamp/LegacyRubyTimeResolver.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.timestamp;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.time.temporal.ValueRange;
+import java.util.Optional;
+import org.embulk.util.rubytime.RubyChronoFields;
+import org.embulk.util.rubytime.RubyDateTimeResolver;
+import org.embulk.util.rubytime.RubyTemporalQueries;
+import org.embulk.util.rubytime.RubyTemporalQueryResolver;
+
+final class LegacyRubyTimeResolver extends RubyDateTimeResolver {
+    LegacyRubyTimeResolver(
+            final ZoneId defaultZoneId,
+            final int defaultYear,
+            final int defaultMonthOfYear,
+            final int defaultDayOfMonth,
+            final int defaultHourOfDay,
+            final int defaultMinuteOfHour,
+            final int defaultSecondOfMinute,
+            final int defaultNanoOfSecond) {
+        this.defaultZoneId = defaultZoneId;
+        this.defaultYear = defaultYear;
+        this.defaultMonthOfYear = defaultMonthOfYear;
+        this.defaultDayOfMonth = defaultDayOfMonth;
+        this.defaultHourOfDay = defaultHourOfDay;
+        this.defaultMinuteOfHour = defaultMinuteOfHour;
+        this.defaultSecondOfMinute = defaultSecondOfMinute;
+        this.defaultNanoOfSecond = defaultNanoOfSecond;
+    }
+
+    /**
+     * Resolves {@link java.time.temporal.TemporalAccessor}, date-time data parsed by {@link RubyDateTimeFormatter}, with a rule close to Ruby's {@code Time.strptime}.
+     *
+     * @param original  the original date-time data parsed by {@link RubyDateTimeFormatter}, not null
+     * @return the resolved temporal object, not null
+     */
+    @Override
+    public TemporalAccessor resolve(final TemporalAccessor original) {
+        return new ResolvedFromInstant(original, this.toInstant(original));
+    }
+
+    /**
+     * Creates a java.time.Instant instance in legacy Embulk's way from this RubyTimeParsed instance with ZoneId.
+     */
+    private final Instant toInstant(final TemporalAccessor original) {
+        final String zoneName = original.query(RubyTemporalQueries.zone());
+
+        if (original.isSupported(ChronoField.INSTANT_SECONDS) || original.isSupported(RubyChronoFields.INSTANT_MILLIS)) {
+            final Instant instant;
+            if (original.isSupported(RubyChronoFields.INSTANT_MILLIS)) {
+                // INSTANT_MILLIS (%Q) is prioritized if exists.
+                final long instantMillis = original.getLong(RubyChronoFields.INSTANT_MILLIS);
+                instant = Instant.ofEpochMilli(instantMillis);
+            } else {
+                final long instantSeconds = original.getLong(ChronoField.INSTANT_SECONDS);
+                instant = Instant.ofEpochSecond(instantSeconds);
+            }
+
+            if (!this.defaultZoneId.equals(ZoneOffset.UTC)) {
+                // TODO: Warn that a default time zone is specified for epoch seconds.
+            }
+            if (zoneName != null) {
+                // TODO: Warn that the epoch second has a time zone.
+            }
+
+            if (original.isSupported(ChronoField.NANO_OF_SECOND)) {
+                // The fraction part is "added" to the epoch second in case both are specified.
+                // irb(main):002:0> Time.strptime("1500000000.123456789", "%s.%N").nsec
+                // => 123456789
+                // irb(main):003:0> Time.strptime("1500000000456.111111111", "%Q.%N").nsec
+                // => 567111111
+                //
+                // If "sec_fraction" is specified, the value is used like |Time.at(seconds, sec_fraction * 1000000)|.
+                // https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/lib/time.rb?view=markup#l427
+                //
+                // |Time.at| adds "seconds" (the epoch) and "sec_fraction" (the fraction part) with scaling.
+                // https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/time.c?view=markup#l2528
+                //
+                // It behaves the same even if "seconds" is specified as a Rational, not an Integer.
+                // irb(main):004:0> Time.at(Rational(1500000000789, 1000), 100123).nsec
+                // => 889123000
+                final int nanoOfSecond = original.get(ChronoField.NANO_OF_SECOND);
+                if (!instant.isBefore(Instant.EPOCH)) {
+                    return instant.plusNanos(nanoOfSecond);
+                } else {
+                    // NANO_OF_SECOND is a "literal" fraction part of a second, by definition.
+                    // It is because "%N" (NANO_OF_SECOND) is used for calendar date-time, not only for seconds since epoch.
+                    //
+                    // Date._strptime("2019-06-08 12:34:56.789", "%Y-%m-%d %H:%M:%S.%N")
+                    // => {:year=>2019, :mon=>6, :mday=>8, :hour=>12, :min=>34, :sec=>56, :sec_fraction=>(789/1000)}
+                    // Date._strptime("1960-06-08 12:34:56.789", "%Y-%m-%d %H:%M:%S.%N")
+                    // => {:year=>1960, :mon=>6, :mday=>8, :hour=>12, :min=>34, :sec=>56, :sec_fraction=>(789/1000)}
+                    //
+                    // Date._strptime( "123.789", "%s.%N")
+                    // => {:seconds=>123, :sec_fraction=>(789/1000)}
+                    // Date._strptime("-123.789", "%s.%N")
+                    // => {:seconds=>-123, :sec_fraction=>(789/1000)}
+                    //
+                    // Then, if second's integer part is negative, the fraction part must be considered as negative.
+                    // The Ruby interpreter does the same.
+                    //
+                    // See: https://git.ruby-lang.org/ruby.git/tree/lib/time.rb?id=v2_6_3#n449
+                    return instant.minusNanos(nanoOfSecond);
+                }
+            } else {
+                return instant;
+            }
+        }
+
+        final ZoneId zoneId;
+        if (zoneName != null) {
+            zoneId = LegacyDateTimeZones.toZoneId(zoneName);
+            if (zoneId == null) {
+                final Optional<String> originalText = Optional.ofNullable(original.query(RubyTemporalQueries.originalText()));
+                throw new DateTimeParseException("Invalid time zone ID '" + zoneName + "'", originalText.orElse(""), 0);
+            }
+        } else {
+            zoneId = this.defaultZoneId;
+        }
+
+        // Leap seconds are considered as 59 when Ruby converts them to epochs.
+        //
+        // RubyDateTimeFormatter#parse processes a leap second to be 59, and
+        // sets TemporalAccessor#query(DateTimeFormatter.parsedLeapSecond()) to true.
+        //
+        // Then, parsedLeapSecond is just ignored here.
+        final int secondOfMinute;
+        if (original.isSupported(ChronoField.SECOND_OF_MINUTE)) {
+            secondOfMinute = original.get(ChronoField.SECOND_OF_MINUTE);
+        } else {
+            secondOfMinute = 0;
+        }
+
+        // 24h is considered as 0h of the next day.
+        //
+        // RubyDateTimeFormatter#parse processes 24h to be 0h, and
+        // sets TemporalAccessor#query(DateTimeFormatter.parsedExcessDays()) to 1 day.
+        final int hour;
+        final int excessDays;
+        if (original.isSupported(ChronoField.HOUR_OF_DAY)) {
+            hour = original.get(ChronoField.HOUR_OF_DAY);
+            final Period parsedExcessDays = original.query(DateTimeFormatter.parsedExcessDays());
+            if (parsedExcessDays == null || parsedExcessDays.isZero()) {
+                excessDays = 0;
+            } else if (parsedExcessDays.getDays() == 1 &&
+                       parsedExcessDays.getMonths() == 0 &&
+                       parsedExcessDays.getYears() == 0) {
+                excessDays = 1;
+            } else {
+                throw new DateTimeParseException("Hour is not in the range of 0-24.", "", 0);
+            }
+        } else {
+            hour = 0;
+            excessDays = 0;
+        }
+
+        final int year;
+        if (original.isSupported(ChronoField.YEAR)) {
+            year = original.get(ChronoField.YEAR);
+        } else {
+            year = this.defaultYear;
+        }
+
+        final int minuteOfHour;
+        if (original.isSupported(ChronoField.MINUTE_OF_HOUR)) {
+            minuteOfHour = original.get(ChronoField.MINUTE_OF_HOUR);
+        } else {
+            minuteOfHour = this.defaultMinuteOfHour;
+        }
+
+        final int nanoOfSecond;
+        if (original.isSupported(ChronoField.NANO_OF_SECOND)) {
+            nanoOfSecond = original.get(ChronoField.NANO_OF_SECOND);
+        } else {
+            nanoOfSecond = this.defaultNanoOfSecond;
+        }
+
+        final ZonedDateTime datetime;
+        // yday is more prioritized than mon/mday in Ruby's strptime.
+        if (original.isSupported(ChronoField.DAY_OF_YEAR)) {
+            datetime = ZonedDateTime
+                    .of(year, 1, 1, hour, minuteOfHour, secondOfMinute, nanoOfSecond, zoneId)
+                    .withDayOfYear(original.get(ChronoField.DAY_OF_YEAR))
+                    .plusDays(excessDays);
+        } else {
+            // Ruby parses some invalid "dayOfMonth" that exceeds the largest day of the month, such as 2018-02-31.
+            //
+            // Embulk's legacy timestamp parser follows this Ruby's behavior for a while in v0.9 for compatibility.
+            // Note that it will start rejecting exceeding dates even in v0.9 after a certain interval.
+            //
+            // TODO: Start to reject exceeding dates such as 2018-02-31.
+            //
+            // irb(main):002:0> Time.strptime("2018-02-31 00:00:00", "%Y-%m-%d %H:%M:%S")
+            // => 2018-03-03 00:00:00 -0800
+            //
+            // irb(main):003:0> Time.strptime("2016-02-31 00:00:00", "%Y-%m-%d %H:%M:%S")
+            // => 2016-03-02 00:00:00 -0800
+            //
+            // irb(main):004:0> Time.strptime("2018-11-31 00:00:00", "%Y-%m-%d %H:%M:%S")
+            // => 2018-12-01 00:00:00 -0800
+            //
+            // irb(main):005:0> Time.strptime("2018-02-32 00:00:00", "%Y-%m-%d %H:%M:%S")
+            // ArgumentError: invalid strptime format - `%Y-%m-%d %H:%M:%S'
+            //         from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/time.rb:433:in `strptime'
+            //         from (irb):2
+            //         from /usr/local/bin/irb:11:in `<main>'
+            //
+            // irb(main):006:0> Time.strptime("2018-02-00 00:00:00", "%Y-%m-%d %H:%M:%S")
+            // ArgumentError: invalid strptime format - `%Y-%m-%d %H:%M:%S'
+            //         from /usr/local/Cellar/ruby/2.4.1_1/lib/ruby/2.4.0/time.rb:433:in `strptime'
+            //         from (irb):4
+            //         from /usr/local/bin/irb:11:in `<main>'
+
+            final int monthOfYear;
+            if (original.isSupported(ChronoField.MONTH_OF_YEAR)) {
+                monthOfYear = original.get(ChronoField.MONTH_OF_YEAR);
+            } else {
+                monthOfYear = this.defaultMonthOfYear;
+            }
+
+            final int dayOfMonth;
+            if (original.isSupported(ChronoField.DAY_OF_MONTH)) {
+                dayOfMonth = original.get(ChronoField.DAY_OF_MONTH);
+            } else {
+                dayOfMonth = this.defaultDayOfMonth;
+            }
+
+            int updatedYear = year;
+            int updatedMonthOfYear = monthOfYear;
+            int updatedDayOfMonth = dayOfMonth;
+
+            final int daysInMonth = monthDays(updatedYear, updatedMonthOfYear);
+            if (daysInMonth < updatedDayOfMonth) {
+                updatedMonthOfYear += 1;
+                if (12 < updatedMonthOfYear) {
+                    updatedMonthOfYear = 1;
+                    updatedYear += 1;
+                }
+                updatedDayOfMonth = updatedDayOfMonth - daysInMonth;
+            }
+
+            datetime = ZonedDateTime.of(
+                    updatedYear,
+                    updatedMonthOfYear,
+                    updatedDayOfMonth,
+                    hour,
+                    minuteOfHour,
+                    secondOfMinute,
+                    nanoOfSecond,
+                    zoneId).plusDays(excessDays);
+        }
+
+        return datetime.toInstant();
+    }
+
+    private class ResolvedFromInstant implements TemporalAccessor, RubyTemporalQueryResolver {
+        private ResolvedFromInstant(final TemporalAccessor original, final Instant resolvedInstant) {
+            this.original = original;
+            this.resolvedInstant = resolvedInstant;
+            this.resolvedDateTime = OffsetDateTime.ofInstant(resolvedInstant, ZoneOffset.UTC);
+        }
+
+        @Override
+        public long getLong(final TemporalField field) {
+            if (this.resolvedInstant.isSupported(field)) {
+                // Its own Instant is intentionally prioritized so that a query for Instant does not return
+                // not SECONDS_SINCE_EPOCH + NANO_OF_SECOND unintentionally.
+                // Its Instant may need to be MILLISECONDS_SINCE_EPOCH + NANO_OF_SECOND instead.
+                return this.resolvedInstant.getLong(field);
+            }
+            return this.resolvedDateTime.getLong(field);
+        }
+
+        @Override
+        public boolean isSupported(final TemporalField field) {
+            if (this.resolvedInstant.isSupported(field)) {
+                // Its own Instant is intentionally prioritized so that a query for Instant does not return
+                // not SECONDS_SINCE_EPOCH + NANO_OF_SECOND unintentionally.
+                // Its Instant may need to be MILLISECONDS_SINCE_EPOCH + NANO_OF_SECOND instead.
+                return true;
+            }
+            return this.resolvedDateTime.isSupported(field);
+        }
+
+        @Override
+        public <R> R query(final TemporalQuery<R> query) {
+            if (RubyTemporalQueries.isSpecificQuery(query)) {
+                // Some special queries are prioritized.
+                final R resultOriginal = this.original.query(query);
+                if (resultOriginal != null) {
+                    return resultOriginal;
+                }
+            }
+            final R resultFromResolvedInstant = this.resolvedInstant.query(query);
+            if (resultFromResolvedInstant != null) {
+                // Its own Instant is intentionally prioritized so that a query for Instant does not return
+                // not SECONDS_SINCE_EPOCH + NANO_OF_SECOND unintentionally.
+                // Its Instant may need to be MILLISECONDS_SINCE_EPOCH + NANO_OF_SECOND instead.
+                return resultFromResolvedInstant;
+            }
+            return this.resolvedDateTime.query(query);
+        }
+
+        @Override
+        public ValueRange range(final TemporalField field) {
+            if (this.resolvedInstant.isSupported(field)) {
+                // Its own Instant is intentionally prioritized so that a query for Instant does not return
+                // not SECONDS_SINCE_EPOCH + NANO_OF_SECOND unintentionally.
+                // Its Instant may need to be MILLISECONDS_SINCE_EPOCH + NANO_OF_SECOND instead.
+                return this.resolvedInstant.range(field);
+            }
+            return this.resolvedDateTime.range(field);
+        }
+
+        @Override
+        public String getOriginalText() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getOriginalText();
+            }
+            return null;
+        }
+
+        @Override
+        public String getZone() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getZone();
+            }
+            return null;
+        }
+
+        @Override
+        public String getLeftover() {
+            if (this.original instanceof RubyTemporalQueryResolver) {
+                final RubyTemporalQueryResolver resolver = (RubyTemporalQueryResolver) this.original;
+                return resolver.getLeftover();
+            }
+            return null;
+        }
+
+        private final TemporalAccessor original;
+        private final Instant resolvedInstant;
+        private final OffsetDateTime resolvedDateTime;
+    }
+
+    /**
+     * Returns the number of days in the given month of the given year.
+     */
+    private static int monthDays(final int year, final int monthOfYear) {
+        if (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0)) {
+            return leapYearMonthDays[monthOfYear - 1];
+        } else {
+            return commonYearMonthDays[monthOfYear - 1];
+        }
+    }
+
+    /**
+     * Numbers of days per month and year.
+     */
+    private static final int[] leapYearMonthDays = { 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+    private static final int[] commonYearMonthDays = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+
+    private final ZoneId defaultZoneId;
+    private final int defaultYear;
+    private final int defaultMonthOfYear;
+    private final int defaultDayOfMonth;
+    private final int defaultHourOfDay;
+    private final int defaultMinuteOfHour;
+    private final int defaultSecondOfMinute;
+    private final int defaultNanoOfSecond;
+}

--- a/src/main/java/org/embulk/util/timestamp/LegacyTimestampFormatter.java
+++ b/src/main/java/org/embulk/util/timestamp/LegacyTimestampFormatter.java
@@ -1,0 +1,45 @@
+package org.embulk.util.timestamp;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import org.embulk.util.rubytime.RubyDateTimeFormatter;
+
+class LegacyTimestampFormatter extends TimestampFormatter {
+    LegacyTimestampFormatter(
+            final String pattern,
+            final ZoneId defaultZoneId,
+            final int defaultYear,
+            final int defaultMonthOfYear,
+            final int defaultDayOfMonth) {
+        final LegacyRubyTimeResolver resolver = new LegacyRubyTimeResolver(
+                defaultZoneId,
+                defaultYear,
+                defaultMonthOfYear,
+                defaultDayOfMonth,
+                0,
+                0,
+                0,
+                0);
+        this.rubyFormatter = RubyDateTimeFormatter.ofPattern(pattern).withResolver(resolver);
+    }
+
+    LegacyTimestampFormatter(final String pattern, final ZoneId defaultZoneId) {
+        this(pattern, defaultZoneId, 1970, 1, 1);
+    }
+
+    @Override
+    public final Instant parse(final String text) {
+        if (text == null) {
+            throw new DateTimeParseException("text is null.", text, 0, new NullPointerException());
+        } else if (text.isEmpty()) {
+            throw new DateTimeParseException("text is empty.", text, 0);
+        }
+
+        final TemporalAccessor parsed = this.rubyFormatter.parse(text);
+        return Instant.from(parsed);
+    }
+
+    private final RubyDateTimeFormatter rubyFormatter;
+}

--- a/src/main/java/org/embulk/util/timestamp/RubyTimestampFormatter.java
+++ b/src/main/java/org/embulk/util/timestamp/RubyTimestampFormatter.java
@@ -1,0 +1,38 @@
+package org.embulk.util.timestamp;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import org.embulk.util.rubytime.RubyDateTimeFormatter;
+import org.embulk.util.rubytime.RubyDateTimeResolver;
+
+class RubyTimestampFormatter extends TimestampFormatter {
+    RubyTimestampFormatter(final String pattern, final ZoneOffset defaultZoneOffset) {
+        if (defaultZoneOffset.equals(ZoneOffset.UTC)) {
+            this.rubyFormatter = RubyDateTimeFormatter.ofPattern(pattern);
+        } else {
+            this.rubyFormatter = RubyDateTimeFormatter
+                                         .ofPattern(pattern)
+                                         .withResolver(RubyDateTimeResolver.withDefaultZoneOffset(defaultZoneOffset));
+        }
+        this.pattern = pattern;
+        this.defaultZoneOffset = defaultZoneOffset;
+    }
+
+    @Override
+    public final Instant parse(final String text) {
+        if (text == null) {
+            throw new DateTimeParseException("text is null.", text, 0, new NullPointerException());
+        } else if (text.isEmpty()) {
+            throw new DateTimeParseException("text is empty.", text, 0);
+        }
+
+        final TemporalAccessor parsed = this.rubyFormatter.parse(text);
+        return Instant.from(parsed);
+    }
+
+    private final RubyDateTimeFormatter rubyFormatter;
+    private final String pattern;
+    private final ZoneOffset defaultZoneOffset;
+}

--- a/src/main/java/org/embulk/util/timestamp/TimestampFormatter.java
+++ b/src/main/java/org/embulk/util/timestamp/TimestampFormatter.java
@@ -17,15 +17,265 @@
 package org.embulk.util.timestamp;
 
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Optional;
 
 /**
- * Formatter for printing and parsing date-time strings.
+ * Formatter for parsing a date-time text.
+ *
+ * <p>The formatter is built with a predefined matching pattern, and used for
+ * parsing date-time strings. Patterns include the Ruby style, the Java style,
+ * and the legacy Embulk style ("legacy non-prefixed").
+ *
+ * <p>The Ruby style works like Ruby's
+ * <a href="https://docs.ruby-lang.org/en/2.6.0/Time.html#method-c-strptime">
+ * {@code Time.strptime}</a>. A Ruby-style pattern follows a prefix
+ * {@code "ruby:"}, or built with {@link #builderWithRuby(String)}. For example:
+ *
+ * <pre>{@code TimestampFormatter formatter1 = TimestampFormatter.builder("ruby:%Y-%m-%d %H:%M:%S %Z").build();
+ * Instant instant1 = formatter1.parse("2019-02-28 12:34:56 +09:00");
+ * System.out.println(instant1);  // => "2019-02-28T03:34:56Z"
+ *
+ * // Same as formatter1 without "ruby:".
+ * TimestampFormatter formatter2 = TimestampFormatter.builderWithRuby("%Y-%m-%d %H:%M:%S %Z").build();}</pre>
+ *
+ * <p>The Java style works like {@link java.time.format.DateTimeFormatter}.
+ * A Java-style pattern follows a prefix {@code "java:"}, or built with
+ * {@link #builderWithJava(String)}. For example:
+ *
+ * <pre>{@code TimestampFormatter formatter3 = TimestampFormatter.builder("java:uuuu-MM-dd HH:mm:ss XXXXX").build();
+ * Instant instant3 = formatter3.parse("2019-02-28 12:34:56 +09:00");
+ * System.out.println(instant3);  // => "2019-02-28T03:34:56Z"
+ *
+ * // Same as formatter3 without "java:".
+ * TimestampFormatter formatter4 = TimestampFormatter.builderWithJava("uuuu-MM-dd HH:mm:ss XXXXX").build();}</pre>
+ *
+ * <p>The legacy Embulk style is here for backward compatibility, but it has
+ * some problems in timezones, especially around daylight saving time. A
+ * legacy Embulk-style pattern does not have any prefix, and must be built
+ * with {@link #builder(String, boolean)} with {@code isLegacyEnabled = true}.
+ * For example:
+ *
+ * <pre>{@code TimestampFormatter formatter5 = TimestampFormatter.builder("%Y-%m-%d %H:%M:%S %Z", true).build();
+ * Instant instant5 = formatter5.parse("2019-02-28 12:34:56 +09:00");
+ * System.out.println(instant5);  // => "2019-02-28T03:34:56Z"}</pre>
  */
 public abstract class TimestampFormatter {
+    TimestampFormatter() {}
+
     /**
-     * Parses a timestamp string into java.time.Instant.
+     * Builds a {@link TimestampFormatter} instance with configurations.
+     */
+    public static final class Builder {
+        private Builder(final Prefix prefix, final String pattern, final boolean isLegacyEnabled) {
+            this.isLegacyEnabled = isLegacyEnabled;
+            this.prefix = prefix;
+
+            if (prefix == Prefix.NONE && !isLegacyEnabled) {
+                throw new IllegalArgumentException("isLegacyEnabled must be true to specify a non-prefixed pattern.");
+            }
+
+            this.pattern = pattern;
+            this.defaultZoneOffset = Optional.empty();
+            this.defaultZoneId = Optional.empty();
+            this.defaultYear = 1970;
+            this.defaultMonthOfYear = 1;
+            this.defaultDayOfMonth = 1;
+        }
+
+        private Builder(final String pattern, final boolean isLegacyEnabled) {
+            this.isLegacyEnabled = isLegacyEnabled;
+
+            if (pattern.startsWith("java:")) {
+                this.prefix = Prefix.JAVA;
+                this.pattern = pattern.substring(5);
+            } else if (pattern.startsWith("ruby:")) {
+                this.prefix = Prefix.RUBY;
+                this.pattern = pattern.substring(5);
+            } else if (isLegacyEnabled) {
+                this.prefix = Prefix.NONE;
+                this.pattern = pattern;
+            } else {
+                throw new IllegalArgumentException("isLegacyEnabled must be true to specify a non-prefixed pattern.");
+            }
+
+            this.defaultZoneOffset = Optional.empty();
+            this.defaultZoneId = Optional.empty();
+        }
+
+        /**
+         * Sets the default {@link java.time.ZoneOffset}.
+         *
+         * @param defaultZoneOffset  the default {@link java.time.ZoneOffset}
+         * @return this
+         */
+        public Builder setDefaultZoneOffset(final ZoneOffset defaultZoneOffset) {
+            this.defaultZoneOffset = Optional.of(defaultZoneOffset);
+            return this;
+        }
+
+        /**
+         * Sets the default {@link java.time.ZoneId}.
+         *
+         * <p>Setting {@link java.time.ZoneId} is available only for a legacy non-prefixed matching pattern.
+         *
+         * @param defaultZoneId  the default {@link java.time.ZoneId}
+         * @return this
+         * @throws java.lang.IllegalArgumentException  if called for a prefixed matching pattern
+         */
+        public Builder setDefaultZoneId(final ZoneId defaultZoneId) {
+            if (this.prefix != Prefix.NONE) {
+                throw new IllegalArgumentException("Pattern must be legacy non-prefixed to set default ZoneId.");
+            }
+            this.defaultZoneId = Optional.of(defaultZoneId);
+            return this;
+        }
+
+        /**
+         * Sets the default {@link java.time.ZoneId} parsed from a {@link java.lang.String}.
+         *
+         * <p>Setting {@link java.time.ZoneId} is available only for a legacy non-prefixed matching pattern.
+         *
+         * @param defaultZoneIdString  a {@link java.lang.String} to be parsed into the default {@link java.time.ZoneId}
+         * @return this
+         * @throws java.lang.IllegalArgumentException  if called for a prefixed matching pattern
+         */
+        public Builder setDefaultZoneIdFromString(final String defaultZoneIdString) {
+            return this.setDefaultZoneId(LegacyDateTimeZones.toZoneId(defaultZoneIdString));
+        }
+
+        /**
+         * Sets the default date.
+         *
+         * <p>Setting a default date is available only for a legacy non-prefixed matching pattern.
+         *
+         * @param defaultYear  the default year
+         * @param defaultMonthOfYear  the default month of a year (1-12)
+         * @param defaultDayOfMonth  the default day of a month (1-31)
+         * @return this
+         * @throws java.lang.IllegalArgumentException  if called for a prefixed matching pattern
+         */
+        public Builder setDefaultDate(final int defaultYear, final int defaultMonthOfYear, final int defaultDayOfMonth) {
+            if (this.prefix != Prefix.NONE) {
+                throw new IllegalArgumentException("Pattern must be legacy non-prefixed to set default date.");
+            }
+            this.defaultYear = defaultYear;
+            this.defaultMonthOfYear = defaultMonthOfYear;
+            this.defaultDayOfMonth = defaultDayOfMonth;
+            return this;
+        }
+
+        /**
+         * Builds {@link TimestampFormatter} from the configurations.
+         *
+         * @return the {@link TimestampFormatter} built
+         * @throws java.lang.IllegalArgumentException  if invalid
+         */
+        public TimestampFormatter build() {
+            if (this.prefix == Prefix.JAVA) {
+                return new JavaTimestampFormatter(
+                        pattern,
+                        this.defaultZoneOffset.orElse(ZoneOffset.UTC));
+            } else if (this.prefix == Prefix.RUBY) {
+                return new RubyTimestampFormatter(
+                        pattern,
+                        this.defaultZoneOffset.orElse(ZoneOffset.UTC));
+            }
+
+            if (this.isLegacyEnabled) {
+                if (this.defaultZoneOffset.isPresent() && this.defaultZoneId.isPresent()) {
+                    throw new IllegalArgumentException("Both default ZoneId and ZoneOffset are set.");
+                } else if (this.defaultZoneId.isPresent()) {
+                    return new LegacyTimestampFormatter(
+                            pattern,
+                            this.defaultZoneId.get(),
+                            this.defaultYear,
+                            this.defaultMonthOfYear,
+                            this.defaultDayOfMonth);
+                } else {
+                    return new LegacyTimestampFormatter(
+                            pattern,
+                            this.defaultZoneOffset.orElse(ZoneOffset.UTC),
+                            this.defaultYear,
+                            this.defaultMonthOfYear,
+                            this.defaultDayOfMonth);
+                }
+            }
+
+            throw new IllegalArgumentException("isLegacyEnabled must be true to specify a non-prefixed pattern.");
+        }
+
+        private final Prefix prefix;
+        private final String pattern;
+        private final boolean isLegacyEnabled;
+
+        private Optional<ZoneOffset> defaultZoneOffset;
+        private Optional<ZoneId> defaultZoneId;
+        private int defaultYear;
+        private int defaultMonthOfYear;
+        private int defaultDayOfMonth;
+    }
+
+    private enum Prefix {
+        RUBY,
+        JAVA,
+        NONE
+    }
+
+    /**
+     * Creates a {@link TimestampFormatter.Builder} from a matching pattern.
      *
-     * @param text  the text to parse, not null
+     * <p>It can create only for a prefixed matching pattern. If a legacy
+     * non-prefixed pattern is required, call {@link #builder(String, boolean)}
+     * with {@code isLegacyEnabled = true}.
+     *
+     * @param pattern  the matching pattern, which must start from {@code "ruby:"} or {@code "java:"}
+     * @return the {@link TimestampFormatter.Builder} created
+     */
+    public static Builder builder(final String pattern) {
+        return builder(pattern, false);
+    }
+
+    /**
+     * Creates a {@link TimestampFormatter.Builder} from a matching pattern.
+     *
+     * @param pattern  the matching pattern, which may start from {@code "ruby:"} or {@code "java:"}
+     * @param isLegacyEnabled  {@code true} if a legacy non-prefixed pattern is required
+     * @return the {@link TimestampFormatter.Builder} created
+     */
+    public static Builder builder(final String pattern, final boolean isLegacyEnabled) {
+        return new Builder(pattern, isLegacyEnabled);
+    }
+
+    /**
+     * Creates a {@link TimestampFormatter.Builder} from a Java-style matching pattern.
+     *
+     * <p>It builds a Java-style {@link TimestampFormatter} without the prefix {@code "java:"}.
+     *
+     * @param pattern  the matching pattern, which is Java-style without the prefix {@code "java:"}
+     * @return the {@link TimestampFormatter.Builder} created
+     */
+    public static Builder builderWithJava(final String pattern) {
+        return new Builder(Prefix.JAVA, pattern, false);
+    }
+
+    /**
+     * Creates a {@link TimestampFormatter.Builder} from a Ruby-style matching pattern.
+     *
+     * <p>It builds a Ruby-style {@link TimestampFormatter} without the prefix {@code "ruby:"}.
+     *
+     * @param pattern  the matching pattern, which is Ruby-style without the prefix {@code "ruby:"}
+     * @return the {@link TimestampFormatter.Builder} created
+     */
+    public static Builder builderWithRuby(final String pattern) {
+        return new Builder(Prefix.RUBY, pattern, false);
+    }
+
+    /**
+     * Parses a date-time text into {@link java.time.Instant}.
+     *
+     * @param text  the text to parse, not null nor empty
      *
      * @return the parsed instantaneous point on the time-line, {@link java.time.Instant}, not null
      *

--- a/src/test/java/org/embulk/util/timestamp/TestLegacyDateTimeZones.java
+++ b/src/test/java/org/embulk/util/timestamp/TestLegacyDateTimeZones.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+public class TestLegacyDateTimeZones {
+    @Test
+    public void test() {
+        // TODO: Test more practical equality. (Such as "GMT" v.s. "UTC")
+        assertEquals(ZoneOffset.UTC, LegacyDateTimeZones.toZoneId("Z"));
+        assertEquals(ZoneId.of("Asia/Tokyo"), LegacyDateTimeZones.toZoneId("Asia/Tokyo"));
+        assertEquals(ZoneId.of("-05:00"), LegacyDateTimeZones.toZoneId("EST"));
+        assertEquals(ZoneId.of("-10:00"), LegacyDateTimeZones.toZoneId("HST"));
+        assertEquals(ZoneId.of("Asia/Taipei"), LegacyDateTimeZones.toZoneId("ROC"));
+    }
+}

--- a/src/test/java/org/embulk/util/timestamp/TestTimestampFormatterParse.java
+++ b/src/test/java/org/embulk/util/timestamp/TestTimestampFormatterParse.java
@@ -1,0 +1,1181 @@
+/*
+ * Copyright 2019 The Embulk project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.embulk.util.timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.TemporalAccessor;
+import org.junit.jupiter.api.Test;
+
+/**
+ * TestTimestampParser tests org.embulk.spi.time.TimestampParser.
+ *
+ * Some test cases are imported from Ruby v2.3.1's test/date/test_date_strptime.rb. See its COPYING for license.
+ *
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/test/date/test_date_strptime.rb?view=markup">test/date/test_date_strptime.rb</a>
+ * @see <a href="https://svn.ruby-lang.org/cgi-bin/viewvc.cgi/tags/v2_3_1/COPYING?view=markup">COPYING</a>
+ */
+public class TestTimestampFormatterParse {
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaIso8601() {
+        testJavaToParse("2001-02-03", "yyyy-MM-dd", 981158400L);
+        testJavaToParse("2001-02-03", "uuuu-MM-dd", 981158400L);
+
+        // "Java" timestamp parser does not accept second = 60 for the time being.
+
+        testJavaToParse("2001-02-03T23:59:59", "yyyy-MM-dd'T'HH:mm:ss", 981244799L);
+        testJavaToParse("2001-02-03T23:59:59", "uuuu-MM-dd'T'HH:mm:ss", 981244799L);
+        testJavaToParse("2001-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX", 981212399L);
+        testJavaToParse("2001-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 981212399L);
+
+        // "yyyy" is Year of Era, which does not accept negative years for AD.
+        failJavaToParse("-2001-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX");
+        testJavaToParse("-2001-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", -125309754001L);
+
+        testJavaToParse("+012345-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX", 327406287599L);
+        testJavaToParse("+012345-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 327406287599L);
+
+        // "yyyy" is Year of Era, which does not accept negative years for AD.
+        failJavaToParse("-012345-02-03T23:59:59+09:00", "yyyy-MM-dd'T'HH:mm:ssXXXXX");
+        testJavaToParse("-012345-02-03T23:59:59+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", -451734829201L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__3_iso8601() {
+        // "Ruby" timestamp parser takes second = 60 as next second.
+
+        testRubyToParse("2001-02-03", "%Y-%m-%d", 981158400L);
+        testRubyToParse("2001-02-03T23:59:60", "%Y-%m-%dT%H:%M:%S", 981244800L);
+        testRubyToParse("2001-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", 981212400L);
+        testRubyToParse("-2001-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", -125309754000L);
+        testRubyToParse("+012345-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", 327406287600L);
+        testRubyToParse("-012345-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", -451734829200L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__3_iso8601() {
+        testToParse("2001-02-03", "%Y-%m-%d", 981158400L);
+        testToParse("2001-02-03T23:59:60", "%Y-%m-%dT%H:%M:%S", 981244799L);
+        testToParse("2001-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", 981212399L);
+        testToParse("-2001-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", -125309754001L);
+        testToParse("+012345-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", 327406287599L);
+        testToParse("-012345-02-03T23:59:60+09:00", "%Y-%m-%dT%H:%M:%S%Z", -451734829201L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaAsctime() {
+        testJavaToParse("Thu Jul 29 14:47:19 1999", "EEE MMM dd HH:mm:ss uuuu", 933259639L);
+
+        // JFYI: Jul 29 -1999 is Sunday, not Thursday.
+        testJavaToParse("Sun Jul 29 14:47:19 -1999", "EEE MMM dd HH:mm:ss uuuu", -125231389961L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__3_ctime3_asctime3() {
+        testToParse("Thu Jul 29 14:47:19 1999", "%c", 933259639L);
+        testToParse("Thu Jul 29 14:47:19 -1999", "%c", -125231389961L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaTimeZones() {
+        testJavaToParse("Thu Jul 29 16:39:41 -05:00 1999", "EEE MMM dd HH:mm:ss XXXXX uuuu", 933284381L);
+
+        // The short time zone IDs "EST", "MET", "AMT", "AST", and "DST" are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 EST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 MET DST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AMT 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AMT -1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AST 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 AST -1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        // All "GMT", "GMT+..." and "GMT-..." are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 GMT 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+09 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+0908 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT+090807 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09:08 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-09:08:07 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-3.5 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 GMT-3,5 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        // String-ish time zone IDs are not accepted in Java parser.
+        failJavaToParse("Thu Jul 29 16:39:41 Mountain Daylight Time 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+        failJavaToParse("Thu Jul 29 16:39:41 E. Australia Standard Time 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+
+        failJavaToParse("Thu Jul 29 16:39:41 UTC 1999", "EEE MMM dd HH:mm:ss zzz uuuu");
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__3_date1() {
+        // The time zone ID "EST" is recognized in Ruby parser.
+        testRubyToParse("Thu Jul 29 16:39:41 EST 1999", "%a %b %d %H:%M:%S %Z %Y", 933284381L);
+
+        // The time zone IDs "MET", "AMT", "AST", and "DST" are not recognized, and handled as "UTC", in Ruby parser.
+        testRubyToParse("Thu Jul 29 16:39:41 MET DST 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 AMT 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 AMT -1999", "%a %b %d %H:%M:%S %Z %Y", -125231383219L);
+        testRubyToParse("Thu Jul 29 16:39:41 AST 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 AST -1999", "%a %b %d %H:%M:%S %Z %Y", -125231383219L);
+
+        // All "GMT", "GMT+..." and "GMT-..." are not recognized, and handled as "UTC", in Ruby parser.
+        testRubyToParse("Thu Jul 29 16:39:41 GMT+09 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT+0908 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT+090807 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT-09 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT-09:08 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT-09:08:07 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT-3.5 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 GMT-3,5 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+
+        // String-ish time zone IDs are not recognized, and handled as "UTC", in Ruby parser.
+        testRubyToParse("Thu Jul 29 16:39:41 Mountain Daylight Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+        testRubyToParse("Thu Jul 29 16:39:41 E. Australia Standard Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933266381L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__3_date1() {
+        testToParse("Thu Jul 29 16:39:41 EST 1999", "%a %b %d %H:%M:%S %Z %Y", 933284381L);
+        testToParse("Thu Jul 29 16:39:41 MET DST 1999", "%a %b %d %H:%M:%S %Z %Y", 933259181L);
+        // Their time zones are "AMT" actually in Ruby v2.3.1's tests, but "AST" is used here instead.
+        // "AMT" is not recognized even by Ruby v2.3.1's zonetab.
+        testToParse("Thu Jul 29 16:39:41 AST 1999", "%a %b %d %H:%M:%S %Z %Y", 933280781L);
+        testToParse("Thu Jul 29 16:39:41 AST -1999", "%a %b %d %H:%M:%S %Z %Y", -125231368819L);
+        testToParse("Thu Jul 29 16:39:41 GMT+09 1999", "%a %b %d %H:%M:%S %Z %Y", 933233981L);
+        testToParse("Thu Jul 29 16:39:41 GMT+0908 1999", "%a %b %d %H:%M:%S %Z %Y", 933233501L);
+        testToParse("Thu Jul 29 16:39:41 GMT+090807 1999", "%a %b %d %H:%M:%S %Z %Y", 933233494L);
+        testToParse("Thu Jul 29 16:39:41 GMT-09 1999", "%a %b %d %H:%M:%S %Z %Y", 933298781L);
+        testToParse("Thu Jul 29 16:39:41 GMT-09:08 1999", "%a %b %d %H:%M:%S %Z %Y", 933299261L);
+        testToParse("Thu Jul 29 16:39:41 GMT-09:08:07 1999", "%a %b %d %H:%M:%S %Z %Y", 933299268L);
+        testToParse("Thu Jul 29 16:39:41 GMT-3.5 1999", "%a %b %d %H:%M:%S %Z %Y", 933278981L);
+        testToParse("Thu Jul 29 16:39:41 GMT-3,5 1999", "%a %b %d %H:%M:%S %Z %Y", 933278981L);
+        testToParse("Thu Jul 29 16:39:41 Mountain Daylight Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933287981L);
+        testToParse("Thu Jul 29 16:39:41 E. Australia Standard Time 1999", "%a %b %d %H:%M:%S %Z %Y", 933230381L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaRfc822() {
+        // String-ish time zone IDs such as "UT", "GMT", "PDT", and "z" are not accepted in Java parser.
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 UT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 GMT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 PDT", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+        failJavaToParse("Thu, 29 Jul 1999 09:54:21 z", "EEE, dd MMM uuuu HH:mm:ss ZZZ");
+
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 +0900", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933209661L);
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 +0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933225861L);
+        testJavaToParse("Thu, 29 Jul 1999 09:54:21 -0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", 933258261L);
+
+        // JFYI: Jul 29 -1999 is Sunday, not Thursday.
+        testJavaToParse("Sun, 29 Jul -1999 09:54:21 -0430", "EEE, dd MMM uuuu HH:mm:ss ZZZ", -125231391339L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__3_rfc822() {
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 UT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 GMT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+
+        // "PDT" (Pacific Daylight Time) is correctly recognized as -07:00 in Ruby parser, not like the legacy parser.
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 PDT", "%a, %d %b %Y %H:%M:%S %Z", 933267261L);
+
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 z", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 +0900", "%a, %d %b %Y %H:%M:%S %Z", 933209661L);
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 +0430", "%a, %d %b %Y %H:%M:%S %Z", 933225861L);
+        testRubyToParse("Thu, 29 Jul 1999 09:54:21 -0430", "%a, %d %b %Y %H:%M:%S %Z", 933258261L);
+        testRubyToParse("Thu, 29 Jul -1999 09:54:21 -0430", "%a, %d %b %Y %H:%M:%S %Z", -125231391339L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__3_rfc822() {
+        testToParse("Thu, 29 Jul 1999 09:54:21 UT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+        testToParse("Thu, 29 Jul 1999 09:54:21 GMT", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+
+        // It should be 933267261L if PDT (Pacific Daylight Time) is correctly -07:00.
+        //
+        // Joda-Time's DateTimeFormat.forPattern("z").parseMillis("PDT") however returns 8 hours (-08:00).
+        // DateTimeFormat.forPattern("z").parseMillis("PDT") == 28800000
+        // https://github.com/JodaOrg/joda-time/blob/v2.9.2/src/main/java/org/joda/time/DateTimeUtils.java#L446
+        //
+        // Embulk has used it to parse time zones for a very long time since it was v0.1.
+        // https://github.com/embulk/embulk/commit/b97954a5c78397e1269bbb6979d6225dfceb4e05
+        //
+        // It is kept as -08:00 for compatibility as of now.
+        //
+        // TODO: Make time zone parsing consistent.
+        // @see <a href="https://github.com/embulk/embulk/issues/860">https://github.com/embulk/embulk/issues/860</a>
+        testToParse("Thu, 29 Jul 1999 09:54:21 PDT", "%a, %d %b %Y %H:%M:%S %Z", 933270861L);
+
+        testToParse("Thu, 29 Jul 1999 09:54:21 z", "%a, %d %b %Y %H:%M:%S %Z", 933242061L);
+        testToParse("Thu, 29 Jul 1999 09:54:21 +0900", "%a, %d %b %Y %H:%M:%S %Z", 933209661L);
+        testToParse("Thu, 29 Jul 1999 09:54:21 +0430", "%a, %d %b %Y %H:%M:%S %Z", 933225861L);
+        testToParse("Thu, 29 Jul 1999 09:54:21 -0430", "%a, %d %b %Y %H:%M:%S %Z", 933258261L);
+        testToParse("Thu, 29 Jul -1999 09:54:21 -0430", "%a, %d %b %Y %H:%M:%S %Z", -125231391339L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaEtc() {
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        testJavaToParse("06-DEC-99", "dd-MMM-uu", 4100198400L);
+
+        // JFYI: October 31, 2001 is Wednesday, not Sunday.
+        testJavaToParse("wEdnesDay oCtoBer 31 01", "EEEE MMMM dd uu", 1004486400L);
+
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        // Whitespaces are not parsed just with " " in Java parser.
+        // Their "\u000b" are actually "\v" in Ruby v2.3.1's tests. "\v" is not recognized as a character in Java.
+        testJavaToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "MMMM\t\n\u000b\f\r dd,\t\n\u000b\f\ruu",
+                        4095705600L);
+
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("09:02:11 AM", "KK:mm:ss a", 32531L);
+        // "A.M." (with dots) is not accepted in Java parser.
+        failJavaToParse("09:02:11 A.M.", "KK:mm:ss a");
+        testJavaToParse("09:02:11 PM", "KK:mm:ss a", 75731L);
+        // "P.M." (with dots) is not accepted in Java parser.
+        failJavaToParse("09:02:11 P.M.", "KK:mm:ss a");
+
+        // Default dates are always 1970-01-01 in Java parser.
+        // Results differ between "hh" (HOUR_OF_AMPM) and "KK" (CLOCK_HOUR_OF_AMPM) in case the hour is 12.
+        testJavaToParse("12:33:44 AM", "hh:mm:ss a", 2024L);
+        testJavaToParse("12:33:44 AM", "KK:mm:ss a", 45224L);
+        testJavaToParse("01:33:44 AM", "hh:mm:ss a", 5624L);
+        testJavaToParse("01:33:44 AM", "KK:mm:ss a", 5624L);
+        testJavaToParse("11:33:44 AM", "hh:mm:ss a", 41624L);
+        testJavaToParse("11:33:44 AM", "KK:mm:ss a", 41624L);
+        testJavaToParse("12:33:44 PM", "hh:mm:ss a", 45224L);
+        failJavaToParse("12:33:44 PM", "KK:mm:ss a");
+        testJavaToParse("01:33:44 PM", "hh:mm:ss a", 48824L);
+        testJavaToParse("01:33:44 PM", "KK:mm:ss a", 48824L);
+        testJavaToParse("11:33:44 PM", "hh:mm:ss a", 84824L);
+        testJavaToParse("11:33:44 PM", "KK:mm:ss a", 84824L);
+
+        // Their time zones are "AMT" actually in Ruby v2.3.1's tests, but "-04:00" is used here instead.
+        // "AMT" is not recognized even by Ruby v2.3.1's zonetab.
+        testJavaToParse("11:33:44 PM -04:00", "KK:mm:ss a XXXXX", 99224L);
+        failJavaToParse("11:33:44 P.M. -04:00", "KK:mm:ss a XXXXX");
+
+        // Just "+5" is not acceptable as a time zone offset in Java parser.
+        // JFYI: February 1, 2003 is Saturday, not Friday.
+        testJavaToParse("sat1feb034pm+0500", "EEEdMMMuuhaX", 1044097200L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__3_etc() {
+        testRubyToParse("06-DEC-99", "%d-%b-%y", 944438400L);
+        testRubyToParse("sUnDay oCtoBer 31 01", "%A %B %d %y", 1004486400L);
+        // Their "\u000b" are actually "\v" in Ruby v2.3.1's tests. "\v" is not recognized as a character in Java.
+        testRubyToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "%B %d, %y", 939945600L);
+        testRubyToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "%B%t%d,%n%y", 939945600L);
+
+        testRubyToParse("09:02:11 AM", "%I:%M:%S %p", 32531L);
+        testRubyToParse("09:02:11 A.M.", "%I:%M:%S %p", 32531L);
+        testRubyToParse("09:02:11 PM", "%I:%M:%S %p", 75731L);
+        testRubyToParse("09:02:11 P.M.", "%I:%M:%S %p", 75731L);
+
+        testRubyToParse("12:33:44 AM", "%r", 2024L);
+        testRubyToParse("01:33:44 AM", "%r", 5624L);
+        testRubyToParse("11:33:44 AM", "%r", 41624L);
+        testRubyToParse("12:33:44 PM", "%r", 45224L);
+        testRubyToParse("01:33:44 PM", "%r", 48824L);
+        testRubyToParse("11:33:44 PM", "%r", 84824L);
+
+        testRubyToParse("11:33:44 PM AMT", "%I:%M:%S %p %Z", 84824L);
+        testRubyToParse("11:33:44 P.M. AMT", "%I:%M:%S %p %Z", 84824L);
+        // Their time zones are "AMT" actually in Ruby v2.3.1's tests, but "-04:00" is used here instead.
+        // "AMT" is not recognized even by Ruby v2.3.1's zonetab.
+        testRubyToParse("11:33:44 PM -04:00", "%I:%M:%S %p %Z", 99224L);
+        testRubyToParse("11:33:44 P.M. -04:00", "%I:%M:%S %p %Z", 99224L);
+
+        testRubyToParse("fri1feb034pm+5", "%a%d%b%y%H%p%Z", 1044115200L);
+        // The time zone offset is just "+5" in Ruby v2.3.1's tests, but "+05" is used here instead.
+        // "+5" is not recognized, and handled as "UTC", in Ruby parser.
+        testRubyToParse("fri1feb034pm+05", "%a%d%b%y%H%p%Z", 1044097200L);
+    }
+
+    @Test  // Imported from test__strptime__3 in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__3_etc() {
+        testToParse("06-DEC-99", "%d-%b-%y", 944438400L);
+        testToParse("sUnDay oCtoBer 31 01", "%A %B %d %y", 1004486400L);
+        // Their "\u000b" are actually "\v" in Ruby v2.3.1's tests. "\v" is not recognized as a character in Java.
+        testToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "%B %d, %y", 939945600L);
+        testToParse("October\t\n\u000b\f\r 15,\t\n\u000b\f\r99", "%B%t%d,%n%y", 939945600L);
+
+        testToParse("09:02:11 AM", "%I:%M:%S %p", 81955357331L);
+        testToParse("09:02:11 A.M.", "%I:%M:%S %p", 81955357331L);
+        testToParse("09:02:11 PM", "%I:%M:%S %p", 81955400531L);
+        testToParse("09:02:11 P.M.", "%I:%M:%S %p", 81955400531L);
+
+        testToParse("12:33:44 AM", "%r", 81955326824L);
+        testToParse("01:33:44 AM", "%r", 81955330424L);
+        testToParse("11:33:44 AM", "%r", 81955366424L);
+        testToParse("12:33:44 PM", "%r", 81955370024L);
+        testToParse("01:33:44 PM", "%r", 81955373624L);
+        testToParse("11:33:44 PM", "%r", 81955409624L);
+
+        // Their time zones are "AMT" actually in Ruby v2.3.1's tests, but "AST" is used here instead.
+        // "AMT" is not recognized even by Ruby v2.3.1's zonetab.
+        testToParse("11:33:44 PM AST", "%I:%M:%S %p %Z", 81955424024L);
+        testToParse("11:33:44 P.M. AST", "%I:%M:%S %p %Z", 81955424024L);
+
+        testToParse("fri1feb034pm+5", "%a%d%b%y%H%p%Z", 1044097200L);
+    }
+
+    @Test  // Imported from test__strptime__width in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJavaWidth() {
+        // "uu" always parses two-digit years into 2000s in Java parser. ("99" goes to "2099".)
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("99", "uu", 4070908800L);
+        testJavaToParse("01", "uu", 978307200L);
+
+        // Centuries are not accepted in Java parser.
+        // testToParse("19 99", "%C %y", 917049600L);
+        // testToParse("20 01", "%C %y", 980208000L);
+        // testToParse("30 99", "%C %y", 35629718400L);
+        // testToParse("30 01", "%C %y", 32537116800L);
+        // testToParse("1999", "%C%y", 917049600L);
+        // testToParse("2001", "%C%y", 980208000L);
+        // testToParse("3099", "%C%y", 35629718400L);
+        // testToParse("3001", "%C%y", 32537116800L);
+
+        // Default dates are always 1970-01-01 in Java parser.
+        testJavaToParse("20060806", "uuuuuuuu", 632995724851200L);
+        testJavaToParse("20060806", "uuuuMMdd", 1154822400L);
+        // They are not accepted in Java parser.
+        failJavaToParse("2006908906", "uuuu9MM9dd");
+        failJavaToParse("2006908906", "uuuu'9'MM'9'dd");
+        testJavaToParse("12006 08 06", "uuuuu MM dd", 316724342400L);
+        testJavaToParse("12006-08-06", "uuuuu-MM-dd", 316724342400L);
+        testJavaToParse("200608 6", "uuuuMM[ ]d", 1154822400L);
+
+        testJavaToParse("2006333", "uuuuDDD", 1164758400L);
+        // They are not accepted in Java parser.
+        failJavaToParse("20069333", "uuuu9DDD");
+        failJavaToParse("20069333", "uuuu'9'DDD");
+        testJavaToParse("12006 333", "uuuuu DDD", 316734278400L);
+        testJavaToParse("12006-333", "uuuuu-DDD", 316734278400L);
+
+        testJavaToParse("232425", "HHmmss", 84265L);
+        failJavaToParse("23924925", "%H9%M9%S");
+        failJavaToParse("23924925", "%H'9'%M'9'%S");
+        testJavaToParse("23 24 25", "HH mm ss", 84265L);
+        testJavaToParse("23:24:25", "HH:mm:ss", 84265L);
+        testJavaToParse(" 32425", "[ ]hmmss", 1465L);
+        testJavaToParse(" 32425", "[ ]Kmmss", 1465L);
+
+        // They are intentionally skipped as a month and a day of week are not sufficient to build a timestamp.
+        // [['FriAug', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FriAug', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+    }
+
+    @Test  // Imported from test__strptime__width in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__width() {
+        // Default dates are always 1970-01-01 in Ruby parser. If only the year is specified, the date is 01-01.
+        testRubyToParse("99", "%y", 915148800L);
+        testRubyToParse("01", "%y", 978307200L);
+        testRubyToParse("19 99", "%C %y", 915148800L);
+        testRubyToParse("20 01", "%C %y", 978307200L);
+        testRubyToParse("30 99", "%C %y", 35627817600L);
+        testRubyToParse("30 01", "%C %y", 32535216000L);
+        testRubyToParse("1999", "%C%y", 915148800L);
+        testRubyToParse("2001", "%C%y", 978307200L);
+        testRubyToParse("3099", "%C%y", 35627817600L);
+        testRubyToParse("3001", "%C%y", 32535216000L);
+
+        testRubyToParse("20060806", "%Y", 632995724851200L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testRubyToParse("20060806", "%Y ", 632995724851200L);
+        testRubyToParse("20060806", "%Y%m%d", 1154822400L);
+        testRubyToParse("2006908906", "%Y9%m9%d", 1154822400L);
+        testRubyToParse("12006 08 06", "%Y %m %d", 316724342400L);
+        testRubyToParse("12006-08-06", "%Y-%m-%d", 316724342400L);
+        testRubyToParse("200608 6", "%Y%m%e", 1154822400L);
+
+        // Day of the year (yday; DAY_OF_YEAR) is not recognized, and handled as January 1, in Ruby parser.
+        testRubyToParse("2006333", "%Y%j", 1136073600L);
+        testRubyToParse("20069333", "%Y9%j", 1136073600L);
+        testRubyToParse("12006 333", "%Y %j", 316705593600L);
+        testRubyToParse("12006-333", "%Y-%j", 316705593600L);
+
+        testRubyToParse("232425", "%H%M%S", 84265L);
+        testRubyToParse("23924925", "%H9%M9%S", 84265L);
+        testRubyToParse("23 24 25", "%H %M %S", 84265L);
+        testRubyToParse("23:24:25", "%H:%M:%S", 84265L);
+        testRubyToParse(" 32425", "%k%M%S", 12265L);
+        testRubyToParse(" 32425", "%l%M%S", 12265L);
+
+        // They are intentionally skipped as a month and a day of week are not sufficient to build a timestamp.
+        // [['FriAug', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FriAug', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+    }
+
+    @Test  // Imported from test__strptime__width in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__width() {
+        testToParse("99", "%y", 917049600L);
+        testToParse("01", "%y", 980208000L);
+        testToParse("19 99", "%C %y", 917049600L);
+        testToParse("20 01", "%C %y", 980208000L);
+        testToParse("30 99", "%C %y", 35629718400L);
+        testToParse("30 01", "%C %y", 32537116800L);
+        testToParse("1999", "%C%y", 917049600L);
+        testToParse("2001", "%C%y", 980208000L);
+        testToParse("3099", "%C%y", 35629718400L);
+        testToParse("3001", "%C%y", 32537116800L);
+
+        testToParse("20060806", "%Y", 632995726752000L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testToParse("20060806", "%Y ", 632995726752000L);
+        testToParse("20060806", "%Y%m%d", 1154822400L);
+        testToParse("2006908906", "%Y9%m9%d", 1154822400L);
+        testToParse("12006 08 06", "%Y %m %d", 316724342400L);
+        testToParse("12006-08-06", "%Y-%m-%d", 316724342400L);
+        testToParse("200608 6", "%Y%m%e", 1154822400L);
+
+        testToParse("2006333", "%Y%j", 1164758400L);
+        testToParse("20069333", "%Y9%j", 1164758400L);
+        testToParse("12006 333", "%Y %j", 316734278400L);
+        testToParse("12006-333", "%Y-%j", 316734278400L);
+
+        testToParse("232425", "%H%M%S", 81955409065L);
+        testToParse("23924925", "%H9%M9%S", 81955409065L);
+        testToParse("23 24 25", "%H %M %S", 81955409065L);
+        testToParse("23:24:25", "%H:%M:%S", 81955409065L);
+        testToParse(" 32425", "%k%M%S", 81955337065L);
+        testToParse(" 32425", "%l%M%S", 81955337065L);
+
+        // They are intentionally skipped as a month and a day of week are not sufficient to build a timestamp.
+        // [['FriAug', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FriAug', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%A%B'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+        // [['FridayAugust', '%a%b'], [nil,8,nil,nil,nil,nil,nil,nil,5], __LINE__],
+    }
+
+    // test__strptime__fail is skipped for Java parser.
+
+    @Test  // Imported from test__strptime__fail in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby__strptime__fail() {
+        testRubyToParse("2001.", "%Y.", 978307200L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testRubyToParse("2001. ", "%Y.", 978307200L);
+        testRubyToParse("2001.", "%Y. ", 978307200L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testRubyToParse("2001. ", "%Y. ", 978307200L);
+
+        failRubyToParse("2001", "%Y.");
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        failRubyToParse("2001 ", "%Y.");
+        failRubyToParse("2001", "%Y. ");
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        failRubyToParse("2001 ", "%Y. ");
+
+        failRubyToParse("2001-13-31", "%Y-%m-%d");
+        failRubyToParse("2001-12-00", "%Y-%m-%d");
+        failRubyToParse("2001-12-32", "%Y-%m-%d");
+        failRubyToParse("2001-12-00", "%Y-%m-%e");
+        failRubyToParse("2001-12-32", "%Y-%m-%e");
+        failRubyToParse("2001-12-31", "%y-%m-%d");
+
+        failRubyToParse("2004-000", "%Y-%j");
+        failRubyToParse("2004-367", "%Y-%j");
+        failRubyToParse("2004-366", "%y-%j");
+
+        testRubyToParse("24:59:59", "%H:%M:%S", 89999L);
+        testRubyToParse("24:59:59", "%k:%M:%S", 89999L);
+        testRubyToParse("24:59:60", "%H:%M:%S", 90000L);
+        testRubyToParse("24:59:60", "%k:%M:%S", 90000L);
+
+        failRubyToParse("24:60:59", "%H:%M:%S");
+        failRubyToParse("24:60:59", "%k:%M:%S");
+        failRubyToParse("24:59:61", "%H:%M:%S");
+        failRubyToParse("24:59:61", "%k:%M:%S");
+        failRubyToParse("00:59:59", "%I:%M:%S");
+        failRubyToParse("13:59:59", "%I:%M:%S");
+        failRubyToParse("00:59:59", "%l:%M:%S");
+        failRubyToParse("13:59:59", "%l:%M:%S");
+
+        failRubyToParse("0", "%U");  // "ruby:" version fails to parse this.
+        failRubyToParse("54", "%U");
+        failRubyToParse("0", "%W");  // "ruby:" version fails to parse this.
+        failRubyToParse("54", "%W");
+        failRubyToParse("0", "%V");
+        failRubyToParse("54", "%V");
+        failRubyToParse("0", "%u");
+        failRubyToParse("7", "%u");  // "ruby:" version fails to parse this.
+        failRubyToParse("0", "%w");  // "ruby:" version fails to parse this.
+        failRubyToParse("7", "%w");
+
+        failRubyToParse("Sanday", "%A");
+        failRubyToParse("Jenuary", "%B");
+        failRubyToParse("Sundai", "%A");  // "ruby:" version fails to parse this.
+        testRubyToParse("Januari", "%B", 0L);
+        failRubyToParse("Sundai,", "%A,");
+        failRubyToParse("Januari,", "%B,");
+    }
+
+    @Test  // Imported from test__strptime__fail in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test__strptime__fail() {
+        testToParse("2001.", "%Y.", 980208000L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testToParse("2001. ", "%Y.", 980208000L);
+        testToParse("2001.", "%Y. ", 980208000L);
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        testToParse("2001. ", "%Y. ", 980208000L);
+
+        failToParse("2001", "%Y.");
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        failToParse("2001 ", "%Y.");
+        failToParse("2001", "%Y. ");
+        // Its " " is actually "\s" in Ruby v2.3.1's tests. "\s" is not recognized as a character in Java.
+        failToParse("2001 ", "%Y. ");
+
+        failToParse("2001-13-31", "%Y-%m-%d");
+        failToParse("2001-12-00", "%Y-%m-%d");
+        failToParse("2001-12-32", "%Y-%m-%d");
+        failToParse("2001-12-00", "%Y-%m-%e");
+        failToParse("2001-12-32", "%Y-%m-%e");
+        failToParse("2001-12-31", "%y-%m-%d");
+
+        failToParse("2004-000", "%Y-%j");
+        failToParse("2004-367", "%Y-%j");
+        failToParse("2004-366", "%y-%j");
+
+        testToParse("24:59:59", "%H:%M:%S", 81955414799L);
+        testToParse("24:59:59", "%k:%M:%S", 81955414799L);
+        testToParse("24:59:60", "%H:%M:%S", 81955414799L);
+        testToParse("24:59:60", "%k:%M:%S", 81955414799L);
+
+        failToParse("24:60:59", "%H:%M:%S");
+        failToParse("24:60:59", "%k:%M:%S");
+        failToParse("24:59:61", "%H:%M:%S");
+        failToParse("24:59:61", "%k:%M:%S");
+        failToParse("00:59:59", "%I:%M:%S");
+        failToParse("13:59:59", "%I:%M:%S");
+        failToParse("00:59:59", "%l:%M:%S");
+        failToParse("13:59:59", "%l:%M:%S");
+
+        testToParse("0", "%U", 81955324800L);
+        failToParse("54", "%U");
+        testToParse("0", "%W", 81955324800L);
+        failToParse("54", "%W");
+        failToParse("0", "%V");
+        failToParse("54", "%V");
+        failToParse("0", "%u");
+        testToParse("7", "%u", 81955324800L);
+        testToParse("0", "%w", 81955324800L);
+        failToParse("7", "%w");
+
+        failToParse("Sanday", "%A");
+        failToParse("Jenuary", "%B");
+        testToParse("Sundai", "%A", 81955324800L);
+        testToParse("Januari", "%B", 81955324800L);
+        failToParse("Sundai,", "%A,");
+        failToParse("Januari,", "%B,");
+    }
+
+    @Test  // Imported partially from test_strptime in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testJava() {
+        // 'Z' is not accepted in Java parser. Tested with "+00:00" instead.
+        testJavaToParse("2002-03-14T11:22:33+00:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016104953L);
+        testJavaToParse("2002-03-14T11:22:33+09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016072553L);
+        testJavaToParse("2002-03-14T11:22:33-09:00", "uuuu-MM-dd'T'HH:mm:ssXXXXX", 1016137353L);
+        testJavaToParse("2002-03-14T11:22:33.123456789-09:00", "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSXXXXX",
+                        1016137353L, 123456789);
+        testJavaToParse("2002-03-14T11:22:33.123456789-09:00", "uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnnXXXXX",
+                        1016137353L, 123456789);
+    }
+
+    @Test  // Imported partially from test_strptime in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby_strptime() {
+        testRubyToParse("2002-03-14T11:22:33Z", "%Y-%m-%dT%H:%M:%S%Z", 1016104953L);
+        testRubyToParse("2002-03-14T11:22:33+09:00", "%Y-%m-%dT%H:%M:%S%Z", 1016072553L);
+        testRubyToParse("2002-03-14T11:22:33-09:00", "%FT%T%Z", 1016137353L);
+        testRubyToParse("2002-03-14T11:22:33.123456789-09:00", "%FT%T.%N%Z", 1016137353L, 123456789);
+    }
+
+    @Test  // Imported partially from test_strptime in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test_strptime() {
+        testToParse("2002-03-14T11:22:33Z", "%Y-%m-%dT%H:%M:%S%Z", 1016104953L);
+        testToParse("2002-03-14T11:22:33+09:00", "%Y-%m-%dT%H:%M:%S%Z", 1016072553L);
+        testToParse("2002-03-14T11:22:33-09:00", "%FT%T%Z", 1016137353L);
+        testToParse("2002-03-14T11:22:33.123456789-09:00", "%FT%T.%N%Z", 1016137353L, 123456789);
+    }
+
+    // Epoch (nano) seconds are not accepted in Java parser.
+
+    @Test  // Imported from test_strptime__minus in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void testRuby_strptime__minus() {
+        testRubyToParse("-1", "%s", -1L);
+        testRubyToParse("-86400", "%s", -86400L);
+
+        // In |java.time.Instant|, it is always 0 <= nanoAdjustment < 1,000,000,000.
+        // -0.9s is represented like -1s + 100ms.
+        testRubyToParse("-999", "%Q", -1L, 1000000);
+        testRubyToParse("-1000", "%Q", -1L);
+    }
+
+    @Test  // Imported from test_strptime__minus in Ruby v2.3.1's test/date/test_date_strptime.rb.
+    public void test_strptime__minus() {
+        testToParse("-1", "%s", -1L);
+        testToParse("-86400", "%s", -86400L);
+
+        // In |java.time.Instant|, it is always 0 <= nanoAdjustment < 1,000,000,000.
+        // -0.9s is represented like -1s + 100ms.
+        testToParse("-999", "%Q", -1L, 1000000);
+        testToParse("-1000", "%Q", -1L);
+    }
+
+    @Test
+    public void testEpochWithFraction() {
+        testToParse("1500000000.123456789", "%s.%N", 1500000000L, 123456789);
+        testToParse("1500000000456.111111111", "%Q.%N", 1500000000L, 567111111);
+        testToParse("1500000000.123", "%s.%L", 1500000000L, 123000000);
+        testToParse("1500000000456.111", "%Q.%L", 1500000000L, 567000000);
+
+        testToParse("1.5", "%s.%N", 1L, 500000000);
+        testToParse("-1.5", "%s.%N", -2L, 500000000);
+        testToParse("1.000000001", "%s.%N", 1L, 1);
+        testToParse("-1.000000001", "%s.%N", -2L, 999999999);
+    }
+
+    @Test
+    public void testRubyEpochWithFraction() {
+        testRubyToParse("1500000000.123456789", "%s.%N", 1500000000L, 123456789);
+        testRubyToParse("1500000000456.111111111", "%Q.%N", 1500000000L, 567111111);
+        testRubyToParse("1500000000.123", "%s.%L", 1500000000L, 123000000);
+        testRubyToParse("1500000000456.111", "%Q.%L", 1500000000L, 567000000);
+
+        testRubyToParse("1.5", "%s.%N", 1L, 500000000);
+        testRubyToParse("-1.5", "%s.%N", -2L, 500000000);
+        testRubyToParse("1.000000001", "%s.%N", 1L, 1);
+        testRubyToParse("-1.000000001", "%s.%N", -2L, 999999999);
+    }
+
+    @Test
+    public void testExcessDate() {
+        testToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1520035200L);  // 2018-03-03
+        testToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1456876800L);  // 2016-03-02
+        testToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S", 1543622400L);  // 2018-12-01
+
+        failToParse("2018-10-32T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failToParse("2018-13-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        failToParse("2018-00-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failToParse("2018-01-00T00:00:00", "%Y-%m-%dT%H:%M:%S");
+    }
+
+    @Test
+    public void testRubyExcessDate() {
+        failRubyToParse("2018-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2016-02-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-11-31T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        failRubyToParse("2018-10-32T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-13-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        failRubyToParse("2018-00-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+        failRubyToParse("2018-01-00T00:00:00", "%Y-%m-%dT%H:%M:%S");
+    }
+
+    @Test
+    public void testJavaExcessDate() {
+        failJavaToParse("2018-02-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2016-02-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-11-31T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+
+        failJavaToParse("2018-10-32T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-13-01T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+
+        failJavaToParse("2018-00-01T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+        failJavaToParse("2018-01-00T00:00:00", "yyyy-MM-dd'T'HH:mm:ss");
+    }
+
+    @Test
+    public void testSimple() {
+        testToParse("2014-11-19 02:46:29 +0000", "%Y-%m-%d %H:%M:%S %z", 1416365189L);
+    }
+
+    @Test
+    public void testRubySimple() {
+        testRubyToParse("2014-11-19 02:46:29 +0000", "%Y-%m-%d %H:%M:%S %z", 1416365189L);
+    }
+
+    @Test
+    public void testJavaSimple() {
+        testJavaToParse("2014-11-19 02:46:29 +0000", "uuuu-MM-dd HH:mm:ss XXXX", 1416365189L);
+    }
+
+    @Test
+    public void testUnixtimeFormat() {
+        testToParse("1416365189", "%s", 1416365189L);
+    }
+
+    @Test
+    public void testRubyUnixtimeFormat() {
+        testRubyToParse("1416365189", "%s", 1416365189L);
+    }
+
+    @Test
+    public void testDefaultDate() {
+        final TimestampFormatter formatter = TimestampFormatter.builder("%H:%M:%S %Z", true).setDefaultDate(2016, 2, 3).build();
+        final Instant instant = formatter.parse("02:46:29 +0000");
+        assertEquals(instant, Instant.ofEpochSecond(1454467589L, 0));
+    }
+
+    @Test
+    public void testLeapSeconds() {
+        assertParsedTime("2008-12-31T23:56:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767760L, 0));
+        assertParsedTime("2008-12-31T23:59:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767940L, 0));
+        assertParsedTime("2008-12-31T23:59:59", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767999L, 0));
+        assertParsedTime("2008-12-31T23:59:60", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767999L, 0));  // Leap
+        assertParsedTime("2009-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768000L, 0));
+        assertParsedTime("2009-01-01T00:00:01", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768001L, 0));
+        assertParsedTime("2009-01-01T00:01:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768060L, 0));
+        assertParsedTime("2009-01-01T00:03:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768180L, 0));
+    }
+
+    @Test
+    public void testRubyLeapSeconds() {
+        assertParsedTime("2008-12-31T23:56:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767760L, 0));
+        assertParsedTime("2008-12-31T23:59:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767940L, 0));
+        assertParsedTime("2008-12-31T23:59:59", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230767999L, 0));
+        assertParsedTime("2008-12-31T23:59:60", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768000L, 0));  // Leap
+        assertParsedTime("2009-01-01T00:00:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768000L, 0));
+        assertParsedTime("2009-01-01T00:00:01", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768001L, 0));
+        assertParsedTime("2009-01-01T00:01:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768060L, 0));
+        assertParsedTime("2009-01-01T00:03:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(1230768180L, 0));
+    }
+
+    @Test
+    public void testJavaLeapSeconds() {
+        assertParsedTime("2008-12-31T23:56:00", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230767760L, 0));
+        assertParsedTime("2008-12-31T23:59:00", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230767940L, 0));
+        assertParsedTime("2008-12-31T23:59:59", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230767999L, 0));
+        // Leap second is not available in "java:".
+        // assertParsedTime("2008-12-31T23:59:60", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230768000L, 0));
+        assertParsedTime("2009-01-01T00:00:00", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230768000L, 0));
+        assertParsedTime("2009-01-01T00:00:01", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230768001L, 0));
+        assertParsedTime("2009-01-01T00:01:00", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230768060L, 0));
+        assertParsedTime("2009-01-01T00:03:00", "java:uuuu-MM-dd'T'HH:mm:ss", Instant.ofEpochSecond(1230768180L, 0));
+    }
+
+    @Test
+    public void testLarge() {
+        assertParsedTime("-999999999-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(-31557014135596800L, 0));
+        assertFailToParse("-1000000000-12-31T23:59:59", "%Y-%m-%dT%H:%M:%S");
+        assertParsedTime("999999999-12-31T23:59:59", "%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(31556889832780799L, 0));
+        assertFailToParse("1000000000-01-01T00:00:00", "%Y-%m-%dT%H:%M:%S");
+
+        assertParsedTime("9223372036854775", "%s", Instant.ofEpochSecond(9223372036854775L, 0));
+        assertParsedTime("9223372036854776", "%s", Instant.ofEpochSecond(9223372036854776L, 0));
+        assertParsedTime("31556889832780799", "%s", Instant.ofEpochSecond(31556889832780799L, 0));
+        assertFailToParse("31556889832780800", "%s");  // To succeed? 999999999-12-31T23:59:59 + 1s
+        assertFailToParse("31556889864403199", "%s");  // To succeed? Instant.MAX.
+        assertFailToParse("31556889864403200", "%s");
+
+        assertParsedTime("-9223372036854775", "%s", Instant.ofEpochSecond(-9223372036854775L, 0));
+        assertParsedTime("-9223372036854776", "%s", Instant.ofEpochSecond(-9223372036854776L, 0));
+        assertParsedTime("-31556889832780799", "%s", Instant.ofEpochSecond(-31556889832780799L, 0));
+        assertParsedTime("-31556889832780800", "%s", Instant.ofEpochSecond(-31556889832780800L, 0));  // Sure
+
+        assertParsedTime( "-31556889864403199", "%s", Instant.ofEpochSecond(-31556889864403199L, 0));
+        assertFailToParse("-31556889864403200", "%s");  // To succeed? -(Instant.MAX + 1)
+        assertFailToParse("-31557014135596799", "%s");  // To succeed? -999999999-01-01T00:00:00
+        assertFailToParse("-31557014167219200", "%s");  // To succeed? Instant.MIN.
+        assertFailToParse("-31557014167219201", "%s");
+
+        assertParsedTime("9223372036854775807", "%Q", Instant.ofEpochSecond(9223372036854775L, 807000000));
+        assertFailToParse("9223372036854775808", "%Q");
+        assertParsedTime("-9223372036854775807", "%Q", Instant.ofEpochSecond(-9223372036854776L, 193000000));
+        assertFailToParse("-9223372036854775808", "%Q");
+    }
+
+    @Test
+    public void testRubyLarge() {
+        assertParsedTime("-999999999-01-01T00:00:00", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(-31557014135596800L, 0));
+        assertFailToParse("-1000000000-12-31T23:59:59", "ruby:%Y-%m-%dT%H:%M:%S");
+        assertParsedTime("999999999-12-31T23:59:59", "ruby:%Y-%m-%dT%H:%M:%S", Instant.ofEpochSecond(31556889832780799L, 0));
+        assertFailToParse("1000000000-01-01T00:00:00", "ruby:%Y-%m-%dT%H:%M:%S");
+
+        assertParsedTime("9223372036854775", "ruby:%s", Instant.ofEpochSecond(9223372036854775L, 0));
+        assertParsedTime("9223372036854776", "ruby:%s", Instant.ofEpochSecond(9223372036854776L, 0));
+        assertParsedTime("31556889832780799", "ruby:%s", Instant.ofEpochSecond(31556889832780799L, 0));
+        assertFailToParse("31556889832780800", "ruby:%s");  // To succeed? 999999999-12-31T23:59:59 + 1s
+        assertFailToParse("31556889864403199", "ruby:%s");  // To succeed? Instant.MAX.
+        assertFailToParse("31556889864403200", "ruby:%s");
+
+        assertParsedTime("-9223372036854775", "ruby:%s", Instant.ofEpochSecond(-9223372036854775L, 0));
+        assertParsedTime("-9223372036854776", "ruby:%s", Instant.ofEpochSecond(-9223372036854776L, 0));
+        assertParsedTime("-31556889832780799", "ruby:%s", Instant.ofEpochSecond(-31556889832780799L, 0));
+        assertParsedTime("-31556889832780800", "ruby:%s", Instant.ofEpochSecond(-31556889832780800L, 0));  // Sure
+
+        assertParsedTime( "-31556889864403199", "ruby:%s", Instant.ofEpochSecond(-31556889864403199L, 0));
+        assertFailToParse("-31556889864403200", "ruby:%s");  // To succeed? -(Instant.MAX + 1)
+        assertFailToParse("-31557014135596799", "ruby:%s");  // To succeed? -999999999-01-01T00:00:00
+        assertFailToParse("-31557014167219200", "ruby:%s");  // To succeed? Instant.MIN.
+        assertFailToParse("-31557014167219201", "ruby:%s");
+
+        assertParsedTime("9223372036854775807", "ruby:%Q", Instant.ofEpochSecond(9223372036854775L, 807000000));
+        assertFailToParse("9223372036854775808", "ruby:%Q");
+        assertParsedTime("-9223372036854775807", "ruby:%Q", Instant.ofEpochSecond(-9223372036854776L, 193000000));
+        assertFailToParse("-9223372036854775808", "ruby:%Q");
+    }
+
+    @Test
+    public void testJavaLarge() {
+        assertParsedTime("-999999999-01-01T00:00:00", "java:uuuuuuuuu-MM-dd'T'HH:mm:ss",
+                         Instant.ofEpochSecond(-31557014135596800L, 0));
+        assertFailToParse("-1000000000-12-31T23:59:59", "java:uuuuuuuuuu-MM-dd'T'HH:mm:ss");
+        assertParsedTime("999999999-12-31T23:59:59", "java:uuuuuuuuu-MM-dd'T'HH:mm:ss",
+                         Instant.ofEpochSecond(31556889832780799L, 0));
+        assertFailToParse("1000000000-01-01T00:00:00", "java:uuuuuuuuuu-MM-dd'T'HH:mm:ss");
+    }
+
+    @Test
+    public void testSubseconds() {
+        assertFailToParse("2007-08-01T00:00:00.", "%Y-%m-%dT%H:%M:%S.%N");
+        assertFailToParse("2007-08-01T00:00:00.-777777777", "%Y-%m-%dT%H:%M:%S.%N");
+        assertParsedTime("2007-08-01T00:00:00.777777777",
+                         "%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+        assertParsedTime("2007-08-01T00:00:00.77777777777777",
+                         "%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+    }
+
+    @Test
+    public void testRubySubseconds() {
+        assertFailToParse("2007-08-01T00:00:00.", "ruby:%Y-%m-%dT%H:%M:%S.%N");
+        assertFailToParse("2007-08-01T00:00:00.-777777777", "ruby:%Y-%m-%dT%H:%M:%S.%N");
+        assertParsedTime("2007-08-01T00:00:00.777777777",
+                         "ruby:%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+        assertParsedTime("2007-08-01T00:00:00.77777777777777",
+                         "ruby:%Y-%m-%dT%H:%M:%S.%N",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+    }
+
+    @Test
+    public void testJavaSubseconds() {
+        assertFailToParse("2007-08-01T00:00:00.", "java:uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnn");
+        assertFailToParse("2007-08-01T00:00:00.-777777777", "java:uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnn");
+        assertParsedTime("2007-08-01T00:00:00.777777777",
+                         "java:uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnn",
+                         Instant.ofEpochSecond(1185926400L, 777777777));
+        assertFailToParse("2007-08-01T00:00:00.77777777777777", "java:uuuu-MM-dd'T'HH:mm:ss.nnnnnnnnn");  // Fail.
+    }
+
+    @Test
+    public void testDateTimeFromInstant() {
+        final TimestampFormatter formatter = TimestampFormatter.builder("%Q.%N", true).build();
+        final Instant instant = formatter.parse("1500000000456.111111111");
+
+        final OffsetDateTime datetime = instant.atOffset(ZoneOffset.UTC);
+        assertEquals(OffsetDateTime.of(2017, 7, 14, 02, 40, 00, 567111111, ZoneOffset.UTC), datetime);
+    }
+
+    @Test
+    public void testRubyDateTimeFromInstant() {
+        final TimestampFormatter formatter = TimestampFormatter.builder("ruby:%Q.%N", true).build();
+        final Instant instant = formatter.parse("1500000000456.111111111");
+
+        final OffsetDateTime datetime = instant.atOffset(ZoneOffset.UTC);
+        assertEquals(OffsetDateTime.of(2017, 7, 14, 02, 40, 00, 567111111, ZoneOffset.UTC), datetime);
+    }
+
+    @Test
+    public void testOffsets() {
+        assertParsedTime("2019-05-03T00:00:00-00:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "-5" works in legacy.
+        assertParsedTime("2019-05-03T00:00:00-5", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 5, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        assertParsedTime("2019-05-03T00:15:24-01:23:45", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 1, 39, 9, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-01:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 8, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 6, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:14:19+07:49:12", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 2, 17, 25, 7, 0, ZoneOffset.UTC).toInstant());
+
+        // Go forward through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-02-28T23:00:00-05", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-02-28T23:00:00-05:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Go back through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-03-01T05:00:00+09", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-03-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Carry up to the year.
+        assertParsedTime("2019-01-01T05:00:00+09:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2018, 12, 31, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-12-31T21:00:00-07:00", "%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2020, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    public void testRubyOffsets() {
+        assertParsedTime("2019-05-03T00:00:00-00:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "-5" should not work.
+        assertParsedTime("2019-05-03T00:00:00-5", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        assertParsedTime("2019-05-03T00:15:24-01:23:45", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 1, 39, 9, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-01:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:00:00-07:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 3, 8, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-07:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 4, 6, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:14:19+07:49:12", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2019, 5, 2, 17, 25, 7, 0, ZoneOffset.UTC).toInstant());
+
+        // Go forward through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-02-28T23:00:00-05", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-02-28T23:00:00-05:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-02-28T23:00:00-05:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-02-28T23:00:00-05:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Go back through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2000-03-01T05:00:00+09", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-03-01T05:00:00+09:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-03-01T05:00:00+09:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-03-01T05:00:00+09:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Carry up to the year.
+        assertParsedTime("2019-01-01T05:00:00+09:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2018, 12, 31, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-12-31T21:00:00-07:00", "ruby:%Y-%m-%dT%H:%M:%S%Z",
+                         OffsetDateTime.of(2020, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    public void testJavaOffsets() {
+        assertParsedTime("2019-05-03T00:00:00-00:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 3, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "-5" should not work.
+        assertFailToParse("2019-05-03T00:00:00-5", "java:uuuu-MM-dd'T'HH:mm:ssXX");
+
+        assertParsedTime("2019-05-03T00:15:24-01:23:45", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 3, 1, 39, 9, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-01:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 4, 0, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:00:00-07:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 3, 8, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T23:00:00-07:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 4, 6, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-05-03T01:14:19+07:49:12", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2019, 5, 2, 17, 25, 7, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "-05" should not work.
+        assertFailToParse("2000-02-28T23:00:00-05", "java:uuuu-MM-dd'T'HH:mm:ssXX");
+        // Go forward through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2001-02-28T23:00:00-0500", "java:uuuu-MM-dd'T'HH:mm:ssXX",
+                         OffsetDateTime.of(2001, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-02-28T23:00:00-05:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2001, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-02-28T23:00:00-05:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2004, 2, 29, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-02-28T23:00:00-05:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2100, 3, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Just "+09" should not work.
+        assertFailToParse("2000-03-01T05:00:00+09", "java:uuuu-MM-dd'T'HH:mm:ssXX");
+        // Go back through the leap year day (Feb 28 or Feb 29).
+        assertParsedTime("2001-03-01T05:00:00+0900", "java:uuuu-MM-dd'T'HH:mm:ssXX",
+                         OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2001-03-01T05:00:00+09:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2004-03-01T05:00:00+09:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2100-03-01T05:00:00+09:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+
+        // Carry up to the year.
+        assertParsedTime("2019-01-01T05:00:00+09:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2018, 12, 31, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertParsedTime("2019-12-31T21:00:00-07:00", "java:uuuu-MM-dd'T'HH:mm:ssXXXXX",
+                         OffsetDateTime.of(2020, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    public void testDefaultOffsets() {
+        final TimestampFormatter formatter = createOffsetFormatter("%Y-%m-%dT%H:%M:%S", ZoneOffset.ofHours(9));
+        assertEquals(formatter.parse("2000-03-01T05:00:00"),
+                     OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2001-03-01T05:00:00"),
+                     OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2004-03-01T05:00:00"),
+                     OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2100-03-01T05:00:00"),
+                     OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    public void testRubyDefaultOffsets() {
+        final TimestampFormatter formatter = createOffsetFormatter("ruby:%Y-%m-%dT%H:%M:%S", ZoneOffset.ofHours(9));
+        assertEquals(formatter.parse("2000-03-01T05:00:00"),
+                     OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2001-03-01T05:00:00"),
+                     OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2004-03-01T05:00:00"),
+                     OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2100-03-01T05:00:00"),
+                     OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    @Test
+    public void testJavaDefaultOffsets() {
+        final TimestampFormatter formatter = createOffsetFormatter("java:uuuu-MM-dd'T'HH:mm:ss", ZoneOffset.ofHours(9));
+        assertEquals(formatter.parse("2000-03-01T05:00:00"),
+                     OffsetDateTime.of(2000, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2001-03-01T05:00:00"),
+                     OffsetDateTime.of(2001, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2004-03-01T05:00:00"),
+                     OffsetDateTime.of(2004, 2, 29, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+        assertEquals(formatter.parse("2100-03-01T05:00:00"),
+                     OffsetDateTime.of(2100, 2, 28, 20, 0, 0, 0, ZoneOffset.UTC).toInstant());
+    }
+
+    private void testJavaToParse(final String string, final String format, final long second, final int nanoOfSecond) {
+        final TimestampFormatter formatter = TimestampFormatter.builderWithJava(format).build();
+        final Instant timestamp = formatter.parse(string);
+        assertEquals(second, timestamp.getEpochSecond());
+        assertEquals(nanoOfSecond,timestamp.getNano());
+    }
+
+    private void testJavaToParse(final String string, final String format, final long second) {
+        testJavaToParse(string, format, second, 0);
+    }
+
+    private void failJavaToParse(final String string, final String format) {
+        final TimestampFormatter formatter = TimestampFormatter.builderWithJava(format).build();
+        try {
+            formatter.parse(string);
+        } catch (final DateTimeParseException ex) {
+            return;
+        } catch (final DateTimeException ex) {
+            return;
+        }
+        fail();
+    }
+
+    private void testRubyToParse(final String string, final String format, final long second, final int nanoOfSecond) {
+        final TimestampFormatter formatter = TimestampFormatter.builderWithRuby(format).build();
+        final Instant timestamp = formatter.parse(string);
+        assertEquals(second, timestamp.getEpochSecond());
+        assertEquals(nanoOfSecond,timestamp.getNano());
+    }
+
+    private void testRubyToParse(final String string, final String format, final long second) {
+        testRubyToParse(string, format, second, 0);
+    }
+
+    private void failRubyToParse(final String string, final String format) {
+        final TimestampFormatter formatter = TimestampFormatter.builderWithRuby(format).build();
+        try {
+            formatter.parse(string);
+        } catch (final DateTimeParseException ex) {
+            return;
+        }
+        fail();
+    }
+
+    private void testToParse(final String string, final String format, final long second, final int nanoOfSecond) {
+        // Note: UTC.
+        final TimestampFormatter formatter = TimestampFormatter.builder(format, true).setDefaultDate(4567, 1, 23).build();
+        final Instant timestamp = formatter.parse(string);
+        assertEquals(second, timestamp.getEpochSecond());
+        assertEquals(nanoOfSecond,timestamp.getNano());
+    }
+
+    private void testToParse(final String string, final String format, final long second) {
+        testToParse(string, format, second, 0);
+    }
+
+    private void failToParse(final String string, final String format) {
+        // Note: UTC.
+        final TimestampFormatter formatter = TimestampFormatter.builder(format, true).setDefaultDate(4567, 1, 23).build();
+        try {
+            formatter.parse(string);
+        } catch (final DateTimeParseException ex) {
+            return;
+        }
+        fail();
+    }
+
+    private static void assertParsedTime(final String string, final String format, final Instant expected) {
+        final TimestampFormatter formatter = TimestampFormatter.builder(format, true).build();
+        final Instant actualInstant = formatter.parse(string);
+        assertEquals(expected, actualInstant);
+    }
+
+    private static void assertFailToParse(final String string, final String format) {
+        final TimestampFormatter formatter = TimestampFormatter.builder(format, true).build();
+        try {
+            formatter.parse(string);
+        } catch (final DateTimeParseException ex) {
+            return;
+        } catch (final DateTimeException ex) {
+            return;
+        }
+        fail();
+    }
+
+    private static TimestampFormatter createOffsetFormatter(final String format, final ZoneOffset offset) {
+        return TimestampFormatter
+                       .builder(format, true)
+                       .setDefaultZoneOffset(offset)
+                       .build();
+    }
+}


### PR DESCRIPTION
https://github.com/embulk/embulk-util-rubytime is now ready, and then starting this embulk-util-timestamp library to replace embulk-core's `org.embulk.spi.time.TimestampParser` and related classes.

Most of the code is imported straightforward from `org.embulk.spi.time.*` classes.

It imports all tests from `org.embulk.spi.time.TestTimestampParser`, and they run successfully.